### PR TITLE
Optimizely support and overall revamp

### DIFF
--- a/Example/JustTweak.xcodeproj/project.pbxproj
+++ b/Example/JustTweak.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4F6422A121A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6422A021A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift */; };
+		4F6422A321A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */; };
 		51A8BD6A5E5948F41EEC2E66 /* Pods_JustTweak_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F594AA2DDEDFFA4C835EACCF /* Pods_JustTweak_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -46,6 +48,8 @@
 /* Begin PBXFileReference section */
 		2A3A7CF0048CBC9CF1917718 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		3432AE8768ED164F737437EA /* Pods-JustTweak_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustTweak_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustTweak_Tests/Pods-JustTweak_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		4F6422A021A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyTweaksConfiguration.swift; sourceTree = "<group>"; };
+		4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ExampleOptimizelyDatafile.json; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.javascript; };
 		607FACD01AFB9204008FA782 /* JustTweak_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustTweak_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -126,9 +130,11 @@
 			isa = PBXGroup;
 			children = (
 				61D2DEBA1D9ECD4D00E6C6FA /* ExampleConfiguration.json */,
+				4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */,
 				61A561381DA6AC4B00839F7F /* GoogleService-Info.plist */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				61A561361DA6A62900839F7F /* FirebaseTweaksConfiguration.swift */,
+				4F6422A021A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -331,6 +337,7 @@
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				61D2DEBB1D9ECD4D00E6C6FA /* ExampleConfiguration.json in Resources */,
 				61A561391DA6AC4B00839F7F /* GoogleService-Info.plist in Resources */,
+				4F6422A321A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 			);
@@ -476,6 +483,7 @@
 				61A561371DA6A62900839F7F /* FirebaseTweaksConfiguration.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
+				4F6422A121A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/JustTweak.xcodeproj/project.pbxproj
+++ b/Example/JustTweak.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		4F6422A121A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6422A021A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift */; };
 		4F6422A321A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */; };
+		4F6422A621A4205B002B69F0 /* Symbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6422A521A4205B002B69F0 /* Symbols.swift */; };
+		4F6422A721A4205B002B69F0 /* Symbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6422A521A4205B002B69F0 /* Symbols.swift */; };
 		51A8BD6A5E5948F41EEC2E66 /* Pods_JustTweak_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F594AA2DDEDFFA4C835EACCF /* Pods_JustTweak_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -50,6 +52,7 @@
 		3432AE8768ED164F737437EA /* Pods-JustTweak_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustTweak_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustTweak_Tests/Pods-JustTweak_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		4F6422A021A2F7FB002B69F0 /* OptimizelyTweaksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyTweaksConfiguration.swift; sourceTree = "<group>"; };
 		4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ExampleOptimizelyDatafile.json; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.javascript; };
+		4F6422A521A4205B002B69F0 /* Symbols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Symbols.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* JustTweak_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustTweak_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -105,11 +108,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4F6422A421A4205B002B69F0 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				4F6422A521A4205B002B69F0 /* Symbols.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
 				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				607FACD21AFB9204008FA782 /* Example for JustTweak */,
+				4F6422A421A4205B002B69F0 /* Shared */,
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
 				A6193D26EFEA5DC6524A162D /* Pods */,
@@ -480,6 +492,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F6422A621A4205B002B69F0 /* Symbols.swift in Sources */,
 				61A561371DA6A62900839F7F /* FirebaseTweaksConfiguration.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
@@ -500,6 +513,7 @@
 				61BE05201DAE88A100288EC7 /* TextTweakTableViewCellTests.swift in Sources */,
 				618A46CE1DAD4DC500B8F5CA /* UserDefaultsTweaksConfigurationTests.swift in Sources */,
 				618A46CC1DAD481400B8F5CA /* TweakExtensionsTests.swift in Sources */,
+				4F6422A721A4205B002B69F0 /* Symbols.swift in Sources */,
 				619938DC1DA7F6E600765852 /* TweaksConfigurationViewControllerTests.swift in Sources */,
 				61BE051E1DAE878600288EC7 /* TestHelpers.swift in Sources */,
 			);

--- a/Example/JustTweak.xcodeproj/project.pbxproj
+++ b/Example/JustTweak.xcodeproj/project.pbxproj
@@ -439,6 +439,12 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-JustTweak_Example/Pods-JustTweak_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
 				"${BUILT_PRODUCTS_DIR}/JustTweak/JustTweak.framework",
+				"${BUILT_PRODUCTS_DIR}/OptimizelySDKCore/OptimizelySDKCore.framework",
+				"${BUILT_PRODUCTS_DIR}/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager.framework",
+				"${BUILT_PRODUCTS_DIR}/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.framework",
+				"${BUILT_PRODUCTS_DIR}/OptimizelySDKShared/OptimizelySDKShared.framework",
+				"${BUILT_PRODUCTS_DIR}/OptimizelySDKUserProfileService/OptimizelySDKUserProfileService.framework",
+				"${BUILT_PRODUCTS_DIR}/OptimizelySDKiOS/OptimizelySDKiOS.framework",
 				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
@@ -446,6 +452,12 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JustTweak.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OptimizelySDKCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OptimizelySDKDatafileManager.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OptimizelySDKEventDispatcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OptimizelySDKShared.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OptimizelySDKUserProfileService.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OptimizelySDKiOS.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);

--- a/Example/JustTweak.xcodeproj/xcshareddata/xcschemes/JustTweak-Example.xcscheme
+++ b/Example/JustTweak.xcodeproj/xcshareddata/xcschemes/JustTweak-Example.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "607FACE41AFB9204008FA782"
@@ -40,9 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -71,7 +70,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/JustTweak/AppDelegate.swift
+++ b/Example/JustTweak/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationDidBecomeActive(_ application: UIApplication) {
-        let shouldShowAlert = configurationsCoordinator.valueForTweakWith(identifier: "greet_on_app_did_become_active")
+        let shouldShowAlert = configurationsCoordinator.valueForTweakWith(feature: "greet_on_app_did_become_active")
         if let shouldShowAlert = shouldShowAlert, shouldShowAlert == true {
             let alertController = UIAlertController(title: "Hello",
                                                     message: "Welcome to this Demo app!",

--- a/Example/JustTweak/AppDelegate.swift
+++ b/Example/JustTweak/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationDidBecomeActive(_ application: UIApplication) {
-        let shouldShowAlert = configurationsCoordinator.valueForTweakWith(feature: "greet_on_app_did_become_active")
+        let shouldShowAlert = configurationsCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.GreetOnAppDidBecomeActive.rawValue)
         if let shouldShowAlert = shouldShowAlert, shouldShowAlert == true {
             let alertController = UIAlertController(title: "Hello",
                                                     message: "Welcome to this Demo app!",
@@ -41,8 +41,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                                  fallbackConfiguration: jsonConfiguration)
         
         let firebaseConfiguration = FirebaseTweaksConfiguration()
-        
-        let configurations: [TweaksConfiguration] = [jsonConfiguration, localConfiguration, firebaseConfiguration]
+
+        let optimizelyConfiguration = OptimizelyTweaksConfiguration()
+
+        let configurations: [TweaksConfiguration] = [jsonConfiguration, localConfiguration, firebaseConfiguration, optimizelyConfiguration]
         configurationsCoordinator = TweaksConfigurationsCoordinator(configurations: configurations)
     }
     

--- a/Example/JustTweak/AppDelegate.swift
+++ b/Example/JustTweak/AppDelegate.swift
@@ -32,17 +32,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func setUpConfigurations() {
-        let jsonFileURL = Bundle.main.url(forResource: "ExampleConfiguration",
-                                                               withExtension: "json")!
+        let jsonFileURL = Bundle.main.url(forResource: "ExampleConfiguration", withExtension: "json")!
         let jsonConfiguration = JSONTweaksConfiguration(defaultValuesFromJSONAtURL: jsonFileURL)!
         
         let userDefaults = UserDefaults.standard
-        let localConfiguration = UserDefaultsTweaksConfiguration(userDefaults: userDefaults,
-                                                                 fallbackConfiguration: jsonConfiguration)
+        let localConfiguration = UserDefaultsTweaksConfiguration(userDefaults: userDefaults)
         
         let firebaseConfiguration = FirebaseTweaksConfiguration()
 
         let optimizelyConfiguration = OptimizelyTweaksConfiguration()
+        optimizelyConfiguration.userId = UUID().uuidString
 
         let configurations: [TweaksConfiguration] = [jsonConfiguration, localConfiguration, firebaseConfiguration, optimizelyConfiguration]
         configurationsCoordinator = TweaksConfigurationsCoordinator(configurations: configurations)

--- a/Example/JustTweak/ExampleConfiguration.json
+++ b/Example/JustTweak/ExampleConfiguration.json
@@ -1,40 +1,37 @@
 {
-    "display_red_view": {
+    "ui_customization-display_red_view": {
         "Title": "Display Red View",
-        "Group": "UI",
-        "Value": true,
-        "CanBeDisplayed": true
+        "Group": "UI Customization",
+        "Value": false
     },
-    "display_yellow_view": {
+    "ui_customization-display_yellow_view": {
         "Title": "Display Yellow View",
-        "Group": "UI",
-        "Value": false,
-        "CanBeDisplayed": true
+        "Group": "UI Customization",
+        "Value": false
     },
-    "display_green_view": {
+    "ui_customization-display_green_view": {
+        "Title": "Display Green View",
+        "Group": "UI Customization",
         "Value": true
     },
-    "greet_on_app_did_become_active": {
-        "Title": "Greet on app launch",
-        "Group": "General",
-        "Value": false,
-        "CanBeDisplayed": true
-    },
-    "tap_to_change_color_enabled": {
-        "Value": true,
-        "CanBeDisplayed": true,
-        "Title": "Tap to change views color"
-    },
-    "red_view_alpha_component": {
-        "CanBeDisplayed": true,
+    "ui_customization-red_view_alpha_component": {
         "Title": "Red View Alpha Component",
-        "Group": "UI",
+        "Group": "UI Customization",
         "Value": 1.0
     },
-    "change_tweaks_button_label_text": {
-        "CanBeDisplayed": true,
+    "ui_customization-change_tweaks_button_label_text": {
         "Title": "Change Tweaks Button Label Text",
-        "Group": "UI",
+        "Group": "UI Customization",
         "Value": "Change Configuration"
+    },
+    "general-greet_on_app_did_become_active": {
+        "Title": "Greet on app launch",
+        "Group": "General",
+        "Value": false
+    },
+    "general-tap_to_change_color_enabled": {
+        "Title": "Tap to change views color",
+        "Group": "General",
+        "Value": true
     }
 }

--- a/Example/JustTweak/ExampleOptimizelyDatafile.json
+++ b/Example/JustTweak/ExampleOptimizelyDatafile.json
@@ -1,0 +1,125 @@
+{
+    "accountId": "12345",
+    "anonymizeIP": false,
+    "botFiltering": false,
+    "projectId": "23456",
+    "revision": "6",
+    "version": "4",
+    "experiments": [
+                    {
+                    "key": "my_experiment",
+                    "id": "45678",
+                    "layerId": "34567",
+                    "status": "Running",
+                    "variations": [
+                                   {
+                                   "id": "56789",
+                                   "key": "control",
+                                   "variables": [
+                                   
+                                   ]
+                                   },
+                                   {
+                                   "id": "67890",
+                                   "key": "treatment",
+                                   "variables": [
+                                   
+                                   ]
+                                   }
+                                   ],
+                    "trafficAllocation": [
+                                          {
+                                          "entityId": "56789",
+                                          "endOfRange": 5000
+                                          },
+                                          {
+                                          "entityId": "67890",
+                                          "endOfRange": 10000
+                                          }
+                                          ],
+                    "audienceIds": [
+                    
+                    ],
+                    "forcedVariations": {
+                    
+                    }
+                    }
+                    ],
+    "featureFlags": [
+                     {
+                     "experimentIds": [
+                     
+                     ],
+                     "id": "56789",
+                     "key": "price_filter",
+                     "rolloutId": "67890",
+                     "variables": [
+                                   {
+                                   "defaultValue": "100",
+                                   "id": "12345",
+                                   "key": "min_price",
+                                   "type": "integer"
+                                   }
+                                   ]
+                     }
+                     ],
+    "events": [
+               {
+               "experimentIds": [
+                                 "34567"
+                                 ],
+               "id": "56789",
+               "key": "my_conversion"
+               }
+               ],
+    "audiences": [
+    
+    ],
+    "attributes": [
+    
+    ],
+    "groups": [
+    
+    ],
+    "rollouts": [
+                 {
+                 "experiments": [
+                                 {
+                                 "audienceIds": [
+                                 
+                                 ],
+                                 "forcedVariations": {
+                                 
+                                 },
+                                 "id": "23456",
+                                 "key": "23456",
+                                 "layerId": "34567",
+                                 "status": "Running",
+                                 "trafficAllocation": [
+                                                       {
+                                                       "endOfRange": 5000,
+                                                       "entityId": "45678"
+                                                       }
+                                                       ],
+                                 "variations": [
+                                                {
+                                                "featureEnabled": true,
+                                                "id": "56789",
+                                                "key": "56789",
+                                                "variables": [
+                                                              {
+                                                              "id": "67890",
+                                                              "value": "100"
+                                                              }
+                                                              ]
+                                                }
+                                                ]
+                                 }
+                                 ],
+                 "id": "78901"
+                 }
+                 ],
+    "variables": [
+    
+    ]
+}

--- a/Example/JustTweak/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/FirebaseTweaksConfiguration.swift
@@ -27,7 +27,7 @@ import FirebaseRemoteConfig
     }
     
     public var logClosure: TweaksLogClosure?
-    public let priority: TweaksConfigurationPriority = .medium
+    public let priority: TweaksConfigurationPriority = .p5
     
     // Google dependencies
     private var configured: Bool = false

--- a/Example/JustTweak/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/FirebaseTweaksConfiguration.swift
@@ -54,15 +54,18 @@ import FirebaseRemoteConfig
     }
     
     public func tweakWith(feature: String) -> Tweak? {
+        return tweakWith(feature: "", variable: feature)
+    }
+    
+    public func tweakWith(feature: String, variable: String) -> Tweak? {
         guard configured else { return nil }
-        let configValue = remoteConfiguration.configValue(forKey: feature)
+        let configValue = remoteConfiguration.configValue(forKey: variable)
         guard configValue.source != .static else { return nil }
         guard let stringValue = configValue.stringValue else { return nil }
-        return Tweak(identifier: feature,
+        return Tweak(identifier: variable,
                      title: nil,
                      group: nil,
                      value: stringValue.tweakValue,
                      canBeDisplayed: false)
     }
-    
 }

--- a/Example/JustTweak/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/FirebaseTweaksConfiguration.swift
@@ -68,4 +68,8 @@ import FirebaseRemoteConfig
                      value: stringValue.tweakValue,
                      canBeDisplayed: false)
     }
+    
+    public func activeVariation(for experiment: String) -> String? {
+        return nil
+    }
 }

--- a/Example/JustTweak/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/FirebaseTweaksConfiguration.swift
@@ -53,12 +53,12 @@ import FirebaseRemoteConfig
         }
     }
     
-    public func tweakWith(identifier: String) -> Tweak? {
+    public func tweakWith(feature: String) -> Tweak? {
         guard configured else { return nil }
-        let configValue = remoteConfiguration.configValue(forKey: identifier)
+        let configValue = remoteConfiguration.configValue(forKey: feature)
         guard configValue.source != .static else { return nil }
         guard let stringValue = configValue.stringValue else { return nil }
-        return Tweak(identifier: identifier,
+        return Tweak(identifier: feature,
                      title: nil,
                      group: nil,
                      value: stringValue.tweakValue,

--- a/Example/JustTweak/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/FirebaseTweaksConfiguration.swift
@@ -53,8 +53,8 @@ import FirebaseRemoteConfig
         }
     }
     
-    public func tweakWith(feature: String) -> Tweak? {
-        return tweakWith(feature: "", variable: feature)
+    public func isFeatureEnabled(_ feature: String) -> Bool {
+        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {

--- a/Example/JustTweak/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/FirebaseTweaksConfiguration.swift
@@ -7,7 +7,7 @@ import JustTweak
 import FirebaseAnalytics
 import FirebaseRemoteConfig
 
-@objcMembers public class FirebaseTweaksConfiguration: NSObject, TweaksConfiguration {
+public class FirebaseTweaksConfiguration: NSObject, TweaksConfiguration {
     
     public override init() {
         super.init()
@@ -54,7 +54,7 @@ import FirebaseRemoteConfig
     }
     
     public func isFeatureEnabled(_ feature: String) -> Bool {
-        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
+        return false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {
@@ -62,11 +62,11 @@ import FirebaseRemoteConfig
         let configValue = remoteConfiguration.configValue(forKey: variable)
         guard configValue.source != .static else { return nil }
         guard let stringValue = configValue.stringValue else { return nil }
-        return Tweak(identifier: variable,
+        let identifier = [feature, variable].joined(separator: "-")
+        return Tweak(identifier: identifier,
                      title: nil,
                      group: nil,
-                     value: stringValue.tweakValue,
-                     canBeDisplayed: false)
+                     value: stringValue.tweakValue)
     }
     
     public func activeVariation(for experiment: String) -> String? {

--- a/Example/JustTweak/OptimizelyTweaksConfiguration.swift
+++ b/Example/JustTweak/OptimizelyTweaksConfiguration.swift
@@ -57,7 +57,7 @@ public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
         }()
         
         if let tweakValue = tweakValue {
-            return Tweak(identifier: variable, title: nil, group: nil, value: tweakValue, canBeDisplayed: false)
+            return Tweak(identifier: variable, title: nil, group: nil, value: tweakValue)
         }
         
         return nil

--- a/Example/JustTweak/OptimizelyTweaksConfiguration.swift
+++ b/Example/JustTweak/OptimizelyTweaksConfiguration.swift
@@ -9,7 +9,7 @@ import OptimizelySDKiOS
 public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
     
     public var logClosure: TweaksLogClosure?
-    public var priority: TweaksConfigurationPriority = .medium
+    public var priority: TweaksConfigurationPriority = .p8
     
     private var optimizelyManager: OPTLYManager?
     private var optimizelyClient: OPTLYClient?

--- a/Example/JustTweak/OptimizelyTweaksConfiguration.swift
+++ b/Example/JustTweak/OptimizelyTweaksConfiguration.swift
@@ -30,9 +30,8 @@ public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
         optimizelyClient = optimizelyManager?.initialize()
     }
     
-    public func tweakWith(feature: String) -> Tweak? {
-        guard let enabled = optimizelyClient?.isFeatureEnabled(feature, userId: nil, attributes: nil) else { return nil }
-        return Tweak(identifier: feature, boolValue: enabled)
+    public func isFeatureEnabled(_ feature: String) -> Bool {
+        return optimizelyClient?.isFeatureEnabled(feature, userId: nil, attributes: nil) ?? false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {

--- a/Example/JustTweak/OptimizelyTweaksConfiguration.swift
+++ b/Example/JustTweak/OptimizelyTweaksConfiguration.swift
@@ -1,0 +1,63 @@
+//
+//  OptimizelyTweaksConfiguration.swift
+//  Copyright (c) 2018 Just Eat Holding Ltd. All rights reserved.
+//
+
+import JustTweak
+import OptimizelySDKiOS
+
+public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
+    
+    public var logClosure: TweaksLogClosure?
+    public var priority: TweaksConfigurationPriority = .medium
+    
+    private var optimizelyManager: OPTLYManager?
+    private var optimizelyClient: OPTLYClient?
+    
+    public override init() {
+        super.init()
+        let useOptimizely = false
+        guard useOptimizely else { return }
+        optimizelyManager = OPTLYManager(builder: OPTLYManagerBuilder(block: { builder in
+            guard let builder = builder,
+                let filePath = Bundle.main.path(forResource: "ExampleOptimizelyDatafile", ofType: "json"),
+                let fileContents = try? String.init(contentsOfFile: filePath, encoding: .utf8),
+                let jsonDatafile = fileContents.data(using: .utf8) else { return }
+            builder.datafile = jsonDatafile
+            builder.sdkKey = "SDK_KEY_HERE"
+        }))
+        
+        optimizelyClient = optimizelyManager?.initialize()
+    }
+    
+    public func tweakWith(feature: String) -> Tweak? {
+        guard let enabled = optimizelyClient?.isFeatureEnabled(feature, userId: nil, attributes: nil) else { return nil }
+        return Tweak(identifier: feature, boolValue: enabled)
+    }
+    
+    public func tweakWith(feature: String, variable: String) -> Tweak? {
+        guard let optimizelyClient = optimizelyClient, optimizelyClient.isFeatureEnabled(feature, userId: nil, attributes: nil) == true else { return nil }
+        
+        let tweakValue: TweakValue? = {
+            if let boolValue = optimizelyClient.getFeatureVariableBoolean(feature, variableKey: variable, userId: nil, attributes: nil)?.boolValue {
+                return boolValue
+            }
+            else if let doubleValue = optimizelyClient.getFeatureVariableDouble(feature, variableKey: variable, userId: nil, attributes: nil)?.doubleValue {
+                return doubleValue
+            }
+            else if let intValue = optimizelyClient.getFeatureVariableInteger(feature, variableKey: variable, userId: nil, attributes: nil)?.intValue {
+                return intValue
+            }
+            else if let stringValue = optimizelyClient.getFeatureVariableString(feature, variableKey: variable, userId: nil, attributes: nil) {
+                return stringValue
+            }
+            return nil
+        }()
+        
+        if let tweakValue = tweakValue {
+            return Tweak(identifier: variable, title: nil, group: nil, value: tweakValue, canBeDisplayed: false)
+        }
+        
+        return nil
+    }
+}

--- a/Example/JustTweak/OptimizelyTweaksConfiguration.swift
+++ b/Example/JustTweak/OptimizelyTweaksConfiguration.swift
@@ -8,11 +8,14 @@ import OptimizelySDKiOS
 
 public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
     
+    private var optimizelyManager: OPTLYManager?
+    private var optimizelyClient: OPTLYClient?
+    
     public var logClosure: TweaksLogClosure?
     public var priority: TweaksConfigurationPriority = .p8
     
-    private var optimizelyManager: OPTLYManager?
-    private var optimizelyClient: OPTLYClient?
+    public var userId: String!
+    public var attributes: [String : String]?
     
     public override init() {
         super.init()
@@ -26,28 +29,28 @@ public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
             builder.datafile = jsonDatafile
             builder.sdkKey = "SDK_KEY_HERE"
         }))
-        
         optimizelyClient = optimizelyManager?.initialize()
     }
     
     public func isFeatureEnabled(_ feature: String) -> Bool {
-        return optimizelyClient?.isFeatureEnabled(feature, userId: nil, attributes: nil) ?? false
+        return optimizelyClient?.isFeatureEnabled(feature, userId: userId, attributes: attributes) ?? false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard let optimizelyClient = optimizelyClient, optimizelyClient.isFeatureEnabled(feature, userId: nil, attributes: nil) == true else { return nil }
+        guard let optimizelyClient = optimizelyClient else { return nil }
+        guard optimizelyClient.isFeatureEnabled(feature, userId: userId, attributes: attributes) == true else { return nil }
         
         let tweakValue: TweakValue? = {
-            if let boolValue = optimizelyClient.getFeatureVariableBoolean(feature, variableKey: variable, userId: nil, attributes: nil)?.boolValue {
+            if let boolValue = optimizelyClient.getFeatureVariableBoolean(feature, variableKey: variable, userId: userId, attributes: attributes)?.boolValue {
                 return boolValue
             }
-            else if let doubleValue = optimizelyClient.getFeatureVariableDouble(feature, variableKey: variable, userId: nil, attributes: nil)?.doubleValue {
+            else if let doubleValue = optimizelyClient.getFeatureVariableDouble(feature, variableKey: variable, userId: userId, attributes: attributes)?.doubleValue {
                 return doubleValue
             }
-            else if let intValue = optimizelyClient.getFeatureVariableInteger(feature, variableKey: variable, userId: nil, attributes: nil)?.intValue {
+            else if let intValue = optimizelyClient.getFeatureVariableInteger(feature, variableKey: variable, userId: userId, attributes: attributes)?.intValue {
                 return intValue
             }
-            else if let stringValue = optimizelyClient.getFeatureVariableString(feature, variableKey: variable, userId: nil, attributes: nil) {
+            else if let stringValue = optimizelyClient.getFeatureVariableString(feature, variableKey: variable, userId: userId, attributes: attributes) {
                 return stringValue
             }
             return nil
@@ -61,6 +64,6 @@ public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
     }
     
     public func activeVariation(for experiment: String) -> String? {
-        return optimizelyClient?.activate(experiment, userId: "")?.variationKey
+        return optimizelyClient?.activate(experiment, userId: userId)?.variationKey
     }
 }

--- a/Example/JustTweak/OptimizelyTweaksConfiguration.swift
+++ b/Example/JustTweak/OptimizelyTweaksConfiguration.swift
@@ -59,4 +59,8 @@ public class OptimizelyTweaksConfiguration: NSObject, TweaksConfiguration {
         
         return nil
     }
+    
+    public func activeVariation(for experiment: String) -> String? {
+        return optimizelyClient?.activate(experiment, userId: "")?.variationKey
+    }
 }

--- a/Example/JustTweak/ViewController.swift
+++ b/Example/JustTweak/ViewController.swift
@@ -6,16 +6,21 @@
 import UIKit
 import JustTweak
 
-class ViewController: UIViewController {
+enum Features : String {
+    case UICustomization = "ui_customization"
+}
 
-    private enum ExperimentIdentifiers : String {
-        case RedViewAlpha = "red_view_alpha_component"
-        case DisplayRedView = "display_red_view"
-        case DisplayGreenView = "display_green_view"
-        case DisplayYellowView = "display_yellow_view"
-        case TapToChangeViewColor = "tap_to_change_color_enabled"
-        case ChangeConfigurationButton = "change_tweaks_button_label_text"
-    }
+enum Variables : String {
+    case RedViewAlpha = "red_view_alpha_component"
+    case DisplayRedView = "display_red_view"
+    case DisplayGreenView = "display_green_view"
+    case DisplayYellowView = "display_yellow_view"
+    case TapToChangeViewColor = "tap_to_change_color_enabled"
+    case ChangeConfigurationButton = "change_tweaks_button_label_text"
+    case GreetOnAppDidBecomeActive = "greet_on_app_did_become_active"
+}
+
+class ViewController: UIViewController {
 
     @IBOutlet var redView: UIView!
     @IBOutlet var greenView: UIView!
@@ -27,20 +32,20 @@ class ViewController: UIViewController {
 
     private var canShowRedView: Bool {
         get {
-            let identifier = ExperimentIdentifiers.DisplayRedView.rawValue
-            return valueForExperiment(withIdentifier: identifier).boolValue
+            let variable = Variables.DisplayRedView.rawValue
+            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: variable).boolValue
         }
     }
     private var canShowGreenView: Bool {
         get {
-            let identifier = ExperimentIdentifiers.DisplayGreenView.rawValue
-            return valueForExperiment(withIdentifier: identifier).boolValue
+            let variable = Variables.DisplayGreenView.rawValue
+            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: variable).boolValue
         }
     }
     private var canShowYellowView: Bool {
         get {
-            let identifier = ExperimentIdentifiers.DisplayYellowView.rawValue
-            return valueForExperiment(withIdentifier: identifier).boolValue
+            let variable = Variables.DisplayYellowView.rawValue
+            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: variable).boolValue
         }
     }
 
@@ -61,8 +66,8 @@ class ViewController: UIViewController {
         redView.isHidden = !canShowRedView
         greenView.isHidden = !canShowGreenView
         yellowView.isHidden = !canShowYellowView
-        changeConfigurationButton.setTitle(valueForExperiment(withIdentifier: ExperimentIdentifiers.ChangeConfigurationButton.rawValue).stringValue, for: .normal)
-        redView.alpha = CGFloat(valueForExperiment(withIdentifier: ExperimentIdentifiers.RedViewAlpha.rawValue).floatValue)
+        changeConfigurationButton.setTitle(valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.ChangeConfigurationButton.rawValue).stringValue, for: .normal)
+        redView.alpha = CGFloat(valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.RedViewAlpha.rawValue).floatValue)
     }
     
     internal func setUpGesturesIfNeeded() {
@@ -70,7 +75,7 @@ class ViewController: UIViewController {
             tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(changeViewColor))
             view.addGestureRecognizer(tapGestureRecognizer)
         }
-        tapGestureRecognizer.isEnabled = valueForExperiment(withIdentifier: ExperimentIdentifiers.TapToChangeViewColor.rawValue).boolValue
+        tapGestureRecognizer.isEnabled = valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.TapToChangeViewColor.rawValue).boolValue
     }
     
     @objc internal func changeViewColor() {
@@ -90,8 +95,8 @@ class ViewController: UIViewController {
         present(UINavigationController(rootViewController:viewController), animated: true, completion: nil)
     }
 
-    private func valueForExperiment(withIdentifier identifier: String) -> TweakValue {
-        return configurationsCoordinator?.valueForTweakWith(feature: identifier) ?? 0
+    private func valueForExperiment(feature: String, variable: String) -> TweakValue {
+        return configurationsCoordinator?.valueForTweakWith(feature: feature, variable: variable) ?? 0
     }
 
 }

--- a/Example/JustTweak/ViewController.swift
+++ b/Example/JustTweak/ViewController.swift
@@ -91,7 +91,7 @@ class ViewController: UIViewController {
     }
 
     private func valueForExperiment(withIdentifier identifier: String) -> TweakValue {
-        return configurationsCoordinator?.valueForTweakWith(identifier: identifier) ?? 0
+        return configurationsCoordinator?.valueForTweakWith(feature: identifier) ?? 0
     }
 
 }

--- a/Example/JustTweak/ViewController.swift
+++ b/Example/JustTweak/ViewController.swift
@@ -6,20 +6,6 @@
 import UIKit
 import JustTweak
 
-enum Features : String {
-    case UICustomization = "ui_customization"
-}
-
-enum Variables : String {
-    case RedViewAlpha = "red_view_alpha_component"
-    case DisplayRedView = "display_red_view"
-    case DisplayGreenView = "display_green_view"
-    case DisplayYellowView = "display_yellow_view"
-    case TapToChangeViewColor = "tap_to_change_color_enabled"
-    case ChangeConfigurationButton = "change_tweaks_button_label_text"
-    case GreetOnAppDidBecomeActive = "greet_on_app_did_become_active"
-}
-
 class ViewController: UIViewController {
 
     @IBOutlet var redView: UIView!

--- a/Example/JustTweak/ViewController.swift
+++ b/Example/JustTweak/ViewController.swift
@@ -17,13 +17,19 @@ class ViewController: UIViewController {
     private var tapGestureRecognizer: UITapGestureRecognizer!
     
     private var canShowRedView: Bool {
-        return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue).boolValue
+        get {
+            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue).boolValue
+        }
     }
     private var canShowGreenView: Bool {
-        return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayGreenView.rawValue).boolValue
+        get {
+            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayGreenView.rawValue).boolValue
+        }
     }
     private var canShowYellowView: Bool {
-        return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayYellowView.rawValue).boolValue
+        get {
+            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayYellowView.rawValue).boolValue
+        }
     }
     
     deinit {
@@ -73,7 +79,7 @@ class ViewController: UIViewController {
     }
 
     private func valueForExperiment(feature: String, variable: String) -> TweakValue {
-        return configurationsCoordinator?.valueForTweakWith(feature: feature, variable: variable) ?? 0
+        let value = configurationsCoordinator?.valueForTweakWith(feature: feature, variable: variable)
+        return value ?? 0
     }
-
 }

--- a/Example/JustTweak/ViewController.swift
+++ b/Example/JustTweak/ViewController.swift
@@ -12,33 +12,24 @@ class ViewController: UIViewController {
     @IBOutlet var greenView: UIView!
     @IBOutlet var yellowView: UIView!
     @IBOutlet var changeConfigurationButton: UIButton!
-
+    
     var configurationsCoordinator: TweaksConfigurationsCoordinator?
     private var tapGestureRecognizer: UITapGestureRecognizer!
-
+    
     private var canShowRedView: Bool {
-        get {
-            let variable = Variables.DisplayRedView.rawValue
-            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: variable).boolValue
-        }
+        return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue).boolValue
     }
     private var canShowGreenView: Bool {
-        get {
-            let variable = Variables.DisplayGreenView.rawValue
-            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: variable).boolValue
-        }
+        return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayGreenView.rawValue).boolValue
     }
     private var canShowYellowView: Bool {
-        get {
-            let variable = Variables.DisplayYellowView.rawValue
-            return valueForExperiment(feature: Features.UICustomization.rawValue, variable: variable).boolValue
-        }
+        return valueForExperiment(feature: Features.UICustomization.rawValue, variable: Variables.DisplayYellowView.rawValue).boolValue
     }
-
+    
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         updateView()

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,6 +6,7 @@ use_frameworks!
 target 'JustTweak_Example' do
   pod 'JustTweak', :path => '../'
   pod 'Firebase/RemoteConfig'
+  pod 'OptimizelySDKiOS'
 
   target 'JustTweak_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -36,11 +36,25 @@ PODS:
     - nanopb/encode (= 0.3.8)
   - nanopb/decode (0.3.8)
   - nanopb/encode (0.3.8)
+  - OptimizelySDKCore (2.1.3)
+  - OptimizelySDKDatafileManager (2.1.3):
+    - OptimizelySDKShared (= 2.1.3)
+  - OptimizelySDKEventDispatcher (2.1.3):
+    - OptimizelySDKShared (= 2.1.3)
+  - OptimizelySDKiOS (2.1.3):
+    - OptimizelySDKDatafileManager (= 2.1.3)
+    - OptimizelySDKEventDispatcher (= 2.1.3)
+    - OptimizelySDKUserProfileService (= 2.1.3)
+  - OptimizelySDKShared (2.1.3):
+    - OptimizelySDKCore (= 2.1.3)
+  - OptimizelySDKUserProfileService (2.1.3):
+    - OptimizelySDKShared (= 2.1.3)
   - Protobuf (3.5.0)
 
 DEPENDENCIES:
   - Firebase/RemoteConfig
   - JustTweak (from `../`)
+  - OptimizelySDKiOS
 
 EXTERNAL SOURCES:
   JustTweak:
@@ -56,8 +70,14 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
   JustTweak: df75851891f4e6244ad175cfa8608589c2c38ed3
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  OptimizelySDKCore: a79a8bd1de6c784ed2f9f6d57450adced2cf5245
+  OptimizelySDKDatafileManager: a6ac7dcc05aacfa03b3b9462aaa4b93c59681e1e
+  OptimizelySDKEventDispatcher: e7fbcf2001786e8077da41fccb0533facb84ccfd
+  OptimizelySDKiOS: d96c3ac7b68716a2425fefc94856ad9523cadd6d
+  OptimizelySDKShared: 097bdddda2924026ea913a28e6d2856168295c74
+  OptimizelySDKUserProfileService: 839af3ae439c0e6d441148c7be8e1149544712ae
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
 
-PODFILE CHECKSUM: 2db0e6c19b4429f2f441eefce47a302d49d3b5d3
+PODFILE CHECKSUM: 699b095b8b7f3b37cd7fb3b4f31ba8cb862688e1
 
 COCOAPODS: 1.4.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -54,10 +54,10 @@ SPEC CHECKSUMS:
   FirebaseInstanceID: 148c25c986c8699e67304b114e365713dce467f2
   FirebaseRemoteConfig: 451fe8e9c43ac1e7a137ad2a42189bfc8c2c3ebc
   GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
-  JustTweak: abb2129066c3c5e066b791cbb97fc1fb396f4334
+  JustTweak: df75851891f4e6244ad175cfa8608589c2c38ed3
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
 
 PODFILE CHECKSUM: 2db0e6c19b4429f2f441eefce47a302d49d3b5d3
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.4.0

--- a/Example/Shared/Symbols.swift
+++ b/Example/Shared/Symbols.swift
@@ -1,0 +1,21 @@
+//
+//  Symbols.swift
+//  Copyright (c) 2016 Just Eat Holding Ltd. All rights reserved.
+//
+
+import UIKit
+import JustTweak
+
+enum Features : String {
+    case UICustomization = "ui_customization"
+}
+
+enum Variables : String {
+    case RedViewAlpha = "red_view_alpha_component"
+    case DisplayRedView = "display_red_view"
+    case DisplayGreenView = "display_green_view"
+    case DisplayYellowView = "display_yellow_view"
+    case TapToChangeViewColor = "tap_to_change_color_enabled"
+    case ChangeConfigurationButton = "change_tweaks_button_label_text"
+    case GreetOnAppDidBecomeActive = "greet_on_app_did_become_active"
+}

--- a/Example/Shared/Symbols.swift
+++ b/Example/Shared/Symbols.swift
@@ -8,6 +8,7 @@ import JustTweak
 
 enum Features : String {
     case UICustomization = "ui_customization"
+    case General = "general"
 }
 
 enum Variables : String {

--- a/Example/Tests/Core/JSONTweaksConfigurationTests.swift
+++ b/Example/Tests/Core/JSONTweaksConfigurationTests.swift
@@ -31,24 +31,25 @@ class JSONTweaksConfigurationTests: XCTestCase {
         XCTAssertNil(configurationWithFileNamed("test_configuration_invalid"))
     }
     
-    func testParsesBoolTweakWithAllValues() {
-        let redViewTweak = Tweak(identifier: Variables.DisplayRedView.rawValue, title: "Display Red View", group: "UI", value: true, canBeDisplayed: true)
+    func testParsesBoolTweak() {
+        let identifier = self.identifier(for: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
+        let redViewTweak = Tweak(identifier: identifier, title: "Display Red View", group: "UI Customization", value: true)
         XCTAssertEqual(redViewTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue))
     }
     
-    func testParsesBoolTweakWithOneValue() {
-        let tapBisTweak = Tweak(identifier: Variables.TapToChangeViewColor.rawValue, title: nil, group: nil, value: true, canBeDisplayed: true)
-        XCTAssertEqual(tapBisTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.TapToChangeViewColor.rawValue))
-    }
-    
-    func testParsesFloatTweakWithAllValues() {
-        let redViewAlphaTweak = Tweak(identifier: Variables.RedViewAlpha.rawValue, title: "Red View Alpha Component", group: "UI", value: 1.0, canBeDisplayed: true)
+    func testParsesFloatTweak() {
+        let identifier = self.identifier(for: Features.UICustomization.rawValue, variable: Variables.RedViewAlpha.rawValue)
+        let redViewAlphaTweak = Tweak(identifier: identifier, title: "Red View Alpha Component", group: "UI Customization", value: 1.0)
         XCTAssertEqual(redViewAlphaTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.RedViewAlpha.rawValue))
     }
     
-    func testParsesStringTweakWithAllValues() {
-        let buttonLabelTweak = Tweak(identifier: Variables.ChangeConfigurationButton.rawValue, title: "Change Tweaks Button Label Text", group: "UI", value: "Change Configuration", canBeDisplayed: true)
+    func testParsesStringTweak() {
+        let identifier = self.identifier(for: Features.UICustomization.rawValue, variable: Variables.ChangeConfigurationButton.rawValue)
+        let buttonLabelTweak = Tweak(identifier: identifier, title: "Change Tweaks Button Label Text", group: "UI Customization", value: "Change Configuration")
         XCTAssertEqual(buttonLabelTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.ChangeConfigurationButton.rawValue))
     }
     
+    private func identifier(for feature: String, variable: String) -> String {
+        return [feature, variable].joined(separator: "-")
+    }
 }

--- a/Example/Tests/Core/JSONTweaksConfigurationTests.swift
+++ b/Example/Tests/Core/JSONTweaksConfigurationTests.swift
@@ -32,23 +32,23 @@ class JSONTweaksConfigurationTests: XCTestCase {
     }
     
     func testParsesBoolTweakWithAllValues() {
-        let redViewTweak = Tweak(identifier: "display_red_view", title: "Display Red View", group: "UI", value: true, canBeDisplayed: true)
-        XCTAssertEqual(redViewTweak, configuration.tweakWith(feature: "display_red_view"))
+        let redViewTweak = Tweak(identifier: Variables.DisplayRedView.rawValue, title: "Display Red View", group: "UI", value: true, canBeDisplayed: true)
+        XCTAssertEqual(redViewTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue))
     }
     
     func testParsesBoolTweakWithOneValue() {
-        let tapBisTweak = Tweak(identifier: "tap_to_change_color_enabled_bis", title: nil, group: nil, value: false, canBeDisplayed: false)
-        XCTAssertEqual(tapBisTweak, configuration.tweakWith(feature: "tap_to_change_color_enabled_bis"))
+        let tapBisTweak = Tweak(identifier: Variables.TapToChangeViewColor.rawValue, title: nil, group: nil, value: true, canBeDisplayed: true)
+        XCTAssertEqual(tapBisTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.TapToChangeViewColor.rawValue))
     }
     
     func testParsesFloatTweakWithAllValues() {
-        let redViewAlphaTweak = Tweak(identifier: "red_view_alpha_component", title: "Red View Alpha Component", group: "UI", value: 1.0, canBeDisplayed: true)
-        XCTAssertEqual(redViewAlphaTweak, configuration.tweakWith(feature: "red_view_alpha_component"))
+        let redViewAlphaTweak = Tweak(identifier: Variables.RedViewAlpha.rawValue, title: "Red View Alpha Component", group: "UI", value: 1.0, canBeDisplayed: true)
+        XCTAssertEqual(redViewAlphaTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.RedViewAlpha.rawValue))
     }
     
     func testParsesStringTweakWithAllValues() {
-        let buttonLabelTweak = Tweak(identifier: "change_tweaks_button_label_text", title: "Change Tweaks Button Label Text", group: "UI", value: "Change Configuration", canBeDisplayed: true)
-        XCTAssertEqual(buttonLabelTweak, configuration.tweakWith(feature: "change_tweaks_button_label_text"))
+        let buttonLabelTweak = Tweak(identifier: Variables.ChangeConfigurationButton.rawValue, title: "Change Tweaks Button Label Text", group: "UI", value: "Change Configuration", canBeDisplayed: true)
+        XCTAssertEqual(buttonLabelTweak, configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.ChangeConfigurationButton.rawValue))
     }
     
 }

--- a/Example/Tests/Core/JSONTweaksConfigurationTests.swift
+++ b/Example/Tests/Core/JSONTweaksConfigurationTests.swift
@@ -33,22 +33,22 @@ class JSONTweaksConfigurationTests: XCTestCase {
     
     func testParsesBoolTweakWithAllValues() {
         let redViewTweak = Tweak(identifier: "display_red_view", title: "Display Red View", group: "UI", value: true, canBeDisplayed: true)
-        XCTAssertEqual(redViewTweak, configuration.tweakWith(identifier: "display_red_view"))
+        XCTAssertEqual(redViewTweak, configuration.tweakWith(feature: "display_red_view"))
     }
     
     func testParsesBoolTweakWithOneValue() {
         let tapBisTweak = Tweak(identifier: "tap_to_change_color_enabled_bis", title: nil, group: nil, value: false, canBeDisplayed: false)
-        XCTAssertEqual(tapBisTweak, configuration.tweakWith(identifier: "tap_to_change_color_enabled_bis"))
+        XCTAssertEqual(tapBisTweak, configuration.tweakWith(feature: "tap_to_change_color_enabled_bis"))
     }
     
     func testParsesFloatTweakWithAllValues() {
         let redViewAlphaTweak = Tweak(identifier: "red_view_alpha_component", title: "Red View Alpha Component", group: "UI", value: 1.0, canBeDisplayed: true)
-        XCTAssertEqual(redViewAlphaTweak, configuration.tweakWith(identifier: "red_view_alpha_component"))
+        XCTAssertEqual(redViewAlphaTweak, configuration.tweakWith(feature: "red_view_alpha_component"))
     }
     
     func testParsesStringTweakWithAllValues() {
         let buttonLabelTweak = Tweak(identifier: "change_tweaks_button_label_text", title: "Change Tweaks Button Label Text", group: "UI", value: "Change Configuration", canBeDisplayed: true)
-        XCTAssertEqual(buttonLabelTweak, configuration.tweakWith(identifier: "change_tweaks_button_label_text"))
+        XCTAssertEqual(buttonLabelTweak, configuration.tweakWith(feature: "change_tweaks_button_label_text"))
     }
     
 }

--- a/Example/Tests/Core/TweakTests.swift
+++ b/Example/Tests/Core/TweakTests.swift
@@ -5,83 +5,83 @@ import JustTweak
 class TweakTests: XCTestCase {
     
     func testTweakHashIsEqualToHashValue() {
-        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false, canBeDisplayed: false)
+        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false)
         XCTAssertEqual(tweak.hashValue, tweak.hash)
     }
     
     func testTweakIsEqualToOtherTweakWithSameAttributes() {
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false, canBeDisplayed: false)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false)
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false)
         XCTAssertEqual(tweakA, tweakB)
     }
     
     func testTweakIsNotEqualToOtherTweakWithSameIdentifierButDifferentAttributes() {
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false, canBeDisplayed: false)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: true, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false)
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: true)
         XCTAssertNotEqual(tweakA, tweakB)
     }
     
     func testTweakIsNotEqualToSomeOtherObjectClaimingToBeATweak() {
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: false)
         let tweakB = NSObject()
         XCTAssertNotEqual(tweakA, tweakB)
     }
     
     func testStringTweakIsEqualToOtherTweakWithSameAttributes() {
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: "Test", canBeDisplayed: false)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: "Test", canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: "Test")
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: "Test")
         XCTAssertEqual(tweakA, tweakB)
     }
     
     func testIntTweakIsEqualToOtherTweakWithSameAttributes() {
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: 1, canBeDisplayed: false)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: 1, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: 1)
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: 1)
         XCTAssertEqual(tweakA, tweakB)
     }
     
     func testFloatTweakIsEqualToOtherTweakWithSameAttributes() {
         let value: Float = 1.0
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertEqual(tweakA, tweakB)
     }
     
     func testDoubleTweakIsEqualToOtherTweakWithSameAttributes() {
         let value: Double = 1.0
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertEqual(tweakA, tweakB)
     }
     
     func testMethodsToBrigeValuesToObjectiveC_Bool() {
         let value: Double = 1.0
-        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweakA = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertFalse(tweakA.boolValue)
-        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: true, canBeDisplayed: false)
+        let tweakB = Tweak(identifier: "some_tweak", title: nil, group: nil, value: true)
         XCTAssertTrue(tweakB.boolValue)
     }
     
     func testMethodsToBrigeValuesToObjectiveC_Int() {
         let value: Int = 1
-        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertEqual(tweak.intValue, value)
     }
     
     func testMethodsToBrigeValuesToObjectiveC_Float() {
         let value: Float = 1.5
-        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertEqual(tweak.floatValue, value)
     }
     
     func testMethodsToBrigeValuesToObjectiveC_Double() {
         let value: Double = 3.66
-        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertEqual(tweak.doubleValue, value)
     }
     
     func testMethodsToBrigeValuesToObjectiveC_String() {
         let value: String = "3.66"
-        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value, canBeDisplayed: false)
+        let tweak = Tweak(identifier: "some_tweak", title: nil, group: nil, value: value)
         XCTAssertEqual(tweak.stringValue, value)
     }
     
@@ -89,8 +89,7 @@ class TweakTests: XCTestCase {
         let tweak = Tweak(identifier: "some_tweak",
                           title: nil,
                           group: nil,
-                          value: 3.5,
-                          canBeDisplayed: false)
+                          value: 3.5)
         XCTAssertEqual(tweak.doubleValue, 3.5)
         XCTAssertEqual(tweak.floatValue, 3.5)
         XCTAssertEqual(tweak.intValue, 3)
@@ -102,8 +101,7 @@ class TweakTests: XCTestCase {
         let tweak = Tweak(identifier: "some_tweak",
                           title: nil,
                           group: nil,
-                          value: true,
-                          canBeDisplayed: false)
+                          value: true)
         XCTAssertEqual(tweak.doubleValue, 0.0)
         XCTAssertEqual(tweak.floatValue, 0.0)
         XCTAssertEqual(tweak.intValue, 0)
@@ -115,8 +113,7 @@ class TweakTests: XCTestCase {
         let tweak = Tweak(identifier: "some_tweak",
                           title: nil,
                           group: nil,
-                          value: "Hello",
-                          canBeDisplayed: false)
+                          value: "Hello")
         XCTAssertEqual(tweak.doubleValue, 0.0)
         XCTAssertEqual(tweak.floatValue, 0.0)
         XCTAssertEqual(tweak.intValue, 0)

--- a/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
+++ b/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
@@ -47,7 +47,7 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
             @objc let priority: TweaksConfigurationPriority = .p10
             @objc var allTweakIdentifiers: [String] { get { return [] } }
             
-            @objc func tweakWith(feature: String) -> Tweak? { return nil }
+            @objc func isFeatureEnabled(_ feature: String) -> Bool { return false }
             @objc func tweakWith(feature: String, variable: String) -> Tweak? { return nil }
             @objc func set(boolValue value: Bool, forTweakWithIdentifier identifier: String) {}
             @objc func set(stringValue value: String, forTweakWithIdentifier identifier: String) {}
@@ -145,8 +145,8 @@ class MockTweaksRemoteConfiguration: NSObject, TweaksConfiguration {
                        "display_green_view": ["Value": false],
                        "greet_on_app_did_become_active": ["Value": true]]
     
-    func tweakWith(feature: String) -> Tweak? {
-        return tweakWith(feature: "", variable: feature)
+    func isFeatureEnabled(_ feature: String) -> Bool {
+        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
     }
     
     func tweakWith(feature: String, variable: String) -> Tweak? {

--- a/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
+++ b/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
@@ -48,6 +48,7 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
             @objc var allTweakIdentifiers: [String] { get { return [] } }
             
             @objc func tweakWith(feature: String) -> Tweak? { return nil }
+            @objc func tweakWith(feature: String, variable: String) -> Tweak? { return nil }
             @objc func set(boolValue value: Bool, forTweakWithIdentifier identifier: String) {}
             @objc func set(stringValue value: String, forTweakWithIdentifier identifier: String) {}
             @objc func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String) {}
@@ -145,8 +146,12 @@ class MockTweaksRemoteConfiguration: NSObject, TweaksConfiguration {
                        "greet_on_app_did_become_active": ["Value": true]]
     
     func tweakWith(feature: String) -> Tweak? {
-        guard let value = knownValues[feature] else { return nil }
-        return Tweak(identifier: feature, title: nil, group: nil, value: value["Value"]!, canBeDisplayed: false)
+        return tweakWith(feature: "", variable: feature)
+    }
+    
+    func tweakWith(feature: String, variable: String) -> Tweak? {
+        guard let value = knownValues[variable] else { return nil }
+        return Tweak(identifier: variable, title: nil, group: nil, value: value["Value"]!, canBeDisplayed: false)
     }
     
 }

--- a/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
+++ b/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
@@ -63,42 +63,42 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
     }
     
     func testReturnsNil_ForUndefinedTweak() {
-        XCTAssertNil(configurationCoordinator.valueForTweakWith(feature: "some_undefined_tweak"))
+        XCTAssertNil(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: "some_undefined_tweak"))
     }
     
     func testReturnsRemoteConfigValue_ForDisplayRedViewTweak() {
-        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: "display_red_view") as! Bool)
+        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue) as! Bool)
     }
     
     func testReturnsRemoteConfigValue_ForDisplayYellowViewTweak() {
-        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: "display_yellow_view") as! Bool)
+        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayYellowView.rawValue) as! Bool)
     }
     
     func testReturnsRemoteConfigValue_ForDisplayGreenViewTweak() {
-        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: "display_green_view") as! Bool)
+        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayGreenView.rawValue) as! Bool)
     }
     
     func testReturnsRemoteConfigValue_ForGreetOnAppDidBecomeActiveTweak() {
-        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: "greet_on_app_did_become_active") as! Bool)
+        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.GreetOnAppDidBecomeActive.rawValue) as! Bool)
     }
     
     func testReturnsJSONConfigValue_ForTapToChangeViewColorTweak_AsYetUnkown() {
-        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: "tap_to_change_color_enabled") as! Bool)
+        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.TapToChangeViewColor.rawValue) as! Bool)
     }
     
     func testReturnsUserSetValue_ForGreetOnAppDidBecomeActiveTweak_AfterUpdatingUserDefaultsConfiguration() {
         let mutableConfiguration = configurationCoordinator.topCustomizableConfiguration()
-        mutableConfiguration?.set(value: false, forTweakWithIdentifier: "greet_on_app_did_become_active")
-        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: "greet_on_app_did_become_active") as! Bool)
+        mutableConfiguration?.set(value: false, forTweakWithIdentifier: Variables.GreetOnAppDidBecomeActive.rawValue)
+        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.GreetOnAppDidBecomeActive.rawValue) as! Bool)
     }
     
     func testReturnsAllDisplayableValues_ForValuesInJSONConfig_AsDisplayable_WithExpectedTitle_WithValueByConfigPriority() {
-        let redViewTweak = Tweak(identifier: "display_red_view", title: "Display Red View", group: "UI", value: true, canBeDisplayed: true)
-        let yellowViewTweak = Tweak(identifier: "display_yellow_view", title: "Display Yellow View", group: "UI", value: false, canBeDisplayed: true)
-        let greetingsTweak = Tweak(identifier: "greet_on_app_did_become_active", title: "Greet on app launch", group: "General", value: true, canBeDisplayed: true)
-        let tapColorTweak = Tweak(identifier: "tap_to_change_color_enabled", title: nil, group: nil, value: true, canBeDisplayed: true)
-        let redViewAlphaTweak = Tweak(identifier: "red_view_alpha_component", title: "Red View Alpha Component", group: "UI", value: 1.0, canBeDisplayed: true)
-        let buttonTitleTweak = Tweak(identifier: "change_tweaks_button_label_text", title: "Change Tweaks Button Label Text", group: "UI", value: "Change Configuration", canBeDisplayed: true)
+        let redViewTweak = Tweak(identifier: Variables.DisplayRedView.rawValue, title: "Display Red View", group: "UI", value: true, canBeDisplayed: true)
+        let yellowViewTweak = Tweak(identifier: Variables.DisplayYellowView.rawValue, title: "Display Yellow View", group: "UI", value: false, canBeDisplayed: true)
+        let greetingsTweak = Tweak(identifier: Variables.GreetOnAppDidBecomeActive.rawValue, title: "Greet on app launch", group: "General", value: true, canBeDisplayed: true)
+        let tapColorTweak = Tweak(identifier: Variables.TapToChangeViewColor.rawValue, title: nil, group: nil, value: true, canBeDisplayed: true)
+        let redViewAlphaTweak = Tweak(identifier: Variables.RedViewAlpha.rawValue, title: "Red View Alpha Component", group: "UI", value: 1.0, canBeDisplayed: true)
+        let buttonTitleTweak = Tweak(identifier: Variables.ChangeConfigurationButton.rawValue, title: "Change Tweaks Button Label Text", group: "UI", value: "Change Configuration", canBeDisplayed: true)
         let expectedTweaks = [
             redViewTweak,
             yellowViewTweak,

--- a/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
+++ b/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
@@ -44,7 +44,7 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
     func testReturnsConsistentMutableConfiguration_IfInitializedWithMultipleMutableConfigurations_WithSamePriority() {
         @objc class MockMutableTweaksConfiguration: NSObject, MutableTweaksConfiguration {
             var logClosure: TweaksLogClosure?
-            @objc let priority: TweaksConfigurationPriority = .high
+            @objc let priority: TweaksConfigurationPriority = .p10
             @objc var allTweakIdentifiers: [String] { get { return [] } }
             
             @objc func tweakWith(feature: String) -> Tweak? { return nil }
@@ -139,7 +139,7 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
 class MockTweaksRemoteConfiguration: NSObject, TweaksConfiguration {
 
     var logClosure: TweaksLogClosure?
-    let priority: TweaksConfigurationPriority = .medium
+    let priority: TweaksConfigurationPriority = .p5
     let knownValues = ["display_red_view": ["Value": true],
                        "display_yellow_view": ["Value": false],
                        "display_green_view": ["Value": false],

--- a/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
+++ b/Example/Tests/Core/TweaksConfigurationCoordinatorTests.swift
@@ -47,7 +47,7 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
             @objc let priority: TweaksConfigurationPriority = .high
             @objc var allTweakIdentifiers: [String] { get { return [] } }
             
-            @objc func tweakWith(identifier: String) -> Tweak? { return nil }
+            @objc func tweakWith(feature: String) -> Tweak? { return nil }
             @objc func set(boolValue value: Bool, forTweakWithIdentifier identifier: String) {}
             @objc func set(stringValue value: String, forTweakWithIdentifier identifier: String) {}
             @objc func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String) {}
@@ -62,33 +62,33 @@ class TweaksConfigurationCoordinatorTests: XCTestCase {
     }
     
     func testReturnsNil_ForUndefinedTweak() {
-        XCTAssertNil(configurationCoordinator.valueForTweakWith(identifier: "some_undefined_tweak"))
+        XCTAssertNil(configurationCoordinator.valueForTweakWith(feature: "some_undefined_tweak"))
     }
     
     func testReturnsRemoteConfigValue_ForDisplayRedViewTweak() {
-        XCTAssertTrue(configurationCoordinator.valueForTweakWith(identifier: "display_red_view") as! Bool)
+        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: "display_red_view") as! Bool)
     }
     
     func testReturnsRemoteConfigValue_ForDisplayYellowViewTweak() {
-        XCTAssertFalse(configurationCoordinator.valueForTweakWith(identifier: "display_yellow_view") as! Bool)
+        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: "display_yellow_view") as! Bool)
     }
     
     func testReturnsRemoteConfigValue_ForDisplayGreenViewTweak() {
-        XCTAssertFalse(configurationCoordinator.valueForTweakWith(identifier: "display_green_view") as! Bool)
+        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: "display_green_view") as! Bool)
     }
     
     func testReturnsRemoteConfigValue_ForGreetOnAppDidBecomeActiveTweak() {
-        XCTAssertTrue(configurationCoordinator.valueForTweakWith(identifier: "greet_on_app_did_become_active") as! Bool)
+        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: "greet_on_app_did_become_active") as! Bool)
     }
     
     func testReturnsJSONConfigValue_ForTapToChangeViewColorTweak_AsYetUnkown() {
-        XCTAssertTrue(configurationCoordinator.valueForTweakWith(identifier: "tap_to_change_color_enabled") as! Bool)
+        XCTAssertTrue(configurationCoordinator.valueForTweakWith(feature: "tap_to_change_color_enabled") as! Bool)
     }
     
     func testReturnsUserSetValue_ForGreetOnAppDidBecomeActiveTweak_AfterUpdatingUserDefaultsConfiguration() {
         let mutableConfiguration = configurationCoordinator.topCustomizableConfiguration()
         mutableConfiguration?.set(value: false, forTweakWithIdentifier: "greet_on_app_did_become_active")
-        XCTAssertFalse(configurationCoordinator.valueForTweakWith(identifier: "greet_on_app_did_become_active") as! Bool)
+        XCTAssertFalse(configurationCoordinator.valueForTweakWith(feature: "greet_on_app_did_become_active") as! Bool)
     }
     
     func testReturnsAllDisplayableValues_ForValuesInJSONConfig_AsDisplayable_WithExpectedTitle_WithValueByConfigPriority() {
@@ -144,9 +144,9 @@ class MockTweaksRemoteConfiguration: NSObject, TweaksConfiguration {
                        "display_green_view": ["Value": false],
                        "greet_on_app_did_become_active": ["Value": true]]
     
-    func tweakWith(identifier: String) -> Tweak? {
-        guard let value = knownValues[identifier] else { return nil }
-        return Tweak(identifier: identifier, title: nil, group: nil, value: value["Value"]!, canBeDisplayed: false)
+    func tweakWith(feature: String) -> Tweak? {
+        guard let value = knownValues[feature] else { return nil }
+        return Tweak(identifier: feature, title: nil, group: nil, value: value["Value"]!, canBeDisplayed: false)
     }
     
 }

--- a/Example/Tests/Core/UserDefaultsTweaksConfigurationTests.swift
+++ b/Example/Tests/Core/UserDefaultsTweaksConfigurationTests.swift
@@ -39,51 +39,51 @@ class UserDefaultsTweaksConfigurationTests: XCTestCase {
         let anotherConfiguration = UserDefaultsTweaksConfiguration(userDefaults: userDefaults)
         anotherConfiguration.set(value: true, forTweakWithIdentifier: "tweak_1")
         let expectedTweak = Tweak(identifier: "tweak_1", title: nil, group: nil, value: true, canBeDisplayed: false)
-        XCTAssertTrue(anotherConfiguration.tweakWith(identifier: "tweak_1") == expectedTweak)
+        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "tweak_1") == expectedTweak)
     }
     
     func testReturnsNilForTweaksThatHaveNoUserDefaultValue() {
-        XCTAssertNil(configuration.tweakWith(identifier: "display_red_view"))
+        XCTAssertNil(configuration.tweakWith(feature: "display_red_view"))
     }
     
     func testReturnsNonNilForTweaksThatHaveNoUserDefaultValue() {
         userDefaults.set("Hello", forKey: "lib.fragments.userDefaultsKey.display_red_view")
-        XCTAssertNotNil(configuration.tweakWith(identifier: "display_red_view"))
+        XCTAssertNotNil(configuration.tweakWith(feature: "display_red_view"))
     }
     
     func testUpdatesValueForTweak_withBool() {
         configuration.set(value: true, forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(identifier: "display_red_view")
+        let tweak = configuration.tweakWith(feature: "display_red_view")
         XCTAssertTrue(tweak!.value == true)
     }
     
     func testUpdatesValueForTweak_withNumber() {
         configuration.set(value: 1, forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(identifier: "display_red_view")
+        let tweak = configuration.tweakWith(feature: "display_red_view")
         XCTAssertTrue(tweak!.value == 1)
     }
     
     func testUpdatesValueForTweak_withString() {
         configuration.set(value: "Hello", forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(identifier: "display_red_view")
+        let tweak = configuration.tweakWith(feature: "display_red_view")
         XCTAssertTrue(tweak!.value == "Hello")
     }
     
     func testUpdatesValueForTweak_withBool_withSupportForObjectiveC() {
         configuration.set(boolValue: true, forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(identifier: "display_red_view")
+        let tweak = configuration.tweakWith(feature: "display_red_view")
         XCTAssertTrue(tweak!.value == true)
     }
     
     func testUpdatesValueForTweak_withNumber_withSupportForObjectiveC() {
         configuration.set(numberValue: NSNumber(value: 1), forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(identifier: "display_red_view")
+        let tweak = configuration.tweakWith(feature: "display_red_view")
         XCTAssertTrue(tweak!.value == 1)
     }
     
     func testUpdatesValueForTweak_withString_withSupportForObjectiveC() {
         configuration.set(stringValue: "Hello", forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(identifier: "display_red_view")
+        let tweak = configuration.tweakWith(feature: "display_red_view")
         XCTAssertTrue(tweak!.value == "Hello")
     }
     

--- a/Example/Tests/Core/UserDefaultsTweaksConfigurationTests.swift
+++ b/Example/Tests/Core/UserDefaultsTweaksConfigurationTests.swift
@@ -39,51 +39,51 @@ class UserDefaultsTweaksConfigurationTests: XCTestCase {
         let anotherConfiguration = UserDefaultsTweaksConfiguration(userDefaults: userDefaults)
         anotherConfiguration.set(value: true, forTweakWithIdentifier: "tweak_1")
         let expectedTweak = Tweak(identifier: "tweak_1", title: nil, group: nil, value: true, canBeDisplayed: false)
-        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "tweak_1") == expectedTweak)
+        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "tweak_1", variable: "tweak_1") == expectedTweak)
     }
     
     func testReturnsNilForTweaksThatHaveNoUserDefaultValue() {
-        XCTAssertNil(configuration.tweakWith(feature: "display_red_view"))
+        XCTAssertNil(configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue))
     }
     
     func testReturnsNonNilForTweaksThatHaveNoUserDefaultValue() {
         userDefaults.set("Hello", forKey: "lib.fragments.userDefaultsKey.display_red_view")
-        XCTAssertNotNil(configuration.tweakWith(feature: "display_red_view"))
+        XCTAssertNotNil(configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue))
     }
     
     func testUpdatesValueForTweak_withBool() {
-        configuration.set(value: true, forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(feature: "display_red_view")
+        configuration.set(value: true, forTweakWithIdentifier: Variables.DisplayRedView.rawValue)
+        let tweak = configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
         XCTAssertTrue(tweak!.value == true)
     }
     
     func testUpdatesValueForTweak_withNumber() {
-        configuration.set(value: 1, forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(feature: "display_red_view")
+        configuration.set(value: 1, forTweakWithIdentifier: Variables.DisplayRedView.rawValue)
+        let tweak = configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
         XCTAssertTrue(tweak!.value == 1)
     }
     
     func testUpdatesValueForTweak_withString() {
-        configuration.set(value: "Hello", forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(feature: "display_red_view")
+        configuration.set(value: "Hello", forTweakWithIdentifier: Variables.DisplayRedView.rawValue)
+        let tweak = configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
         XCTAssertTrue(tweak!.value == "Hello")
     }
     
     func testUpdatesValueForTweak_withBool_withSupportForObjectiveC() {
-        configuration.set(boolValue: true, forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(feature: "display_red_view")
+        configuration.set(boolValue: true, forTweakWithIdentifier: Variables.DisplayRedView.rawValue)
+        let tweak = configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
         XCTAssertTrue(tweak!.value == true)
     }
     
     func testUpdatesValueForTweak_withNumber_withSupportForObjectiveC() {
-        configuration.set(numberValue: NSNumber(value: 1), forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(feature: "display_red_view")
+        configuration.set(numberValue: NSNumber(value: 1), forTweakWithIdentifier: Variables.DisplayRedView.rawValue)
+        let tweak = configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
         XCTAssertTrue(tweak!.value == 1)
     }
     
     func testUpdatesValueForTweak_withString_withSupportForObjectiveC() {
-        configuration.set(stringValue: "Hello", forTweakWithIdentifier: "display_red_view")
-        let tweak = configuration.tweakWith(feature: "display_red_view")
+        configuration.set(stringValue: "Hello", forTweakWithIdentifier: Variables.DisplayRedView.rawValue)
+        let tweak = configuration.tweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayRedView.rawValue)
         XCTAssertTrue(tweak!.value == "Hello")
     }
     

--- a/Example/Tests/UI/TweaksConfigurationViewControllerTests.swift
+++ b/Example/Tests/UI/TweaksConfigurationViewControllerTests.swift
@@ -12,7 +12,7 @@ class ConfigurationViewControllerTests: XCTestCase {
     }
     
     override func tearDown() {
-        viewController.configurationsCoordinator?.topCustomizableConfiguration()?.deleteValue(forTweakWithIdentifier: Variables.DisplayYellowView.rawValue)
+        viewController.configurationsCoordinator?.topCustomizableConfiguration()?.deleteValue(feature: "feature_1", variable: "variable_1")
         viewController = nil
         super.tearDown()
     }
@@ -33,82 +33,73 @@ class ConfigurationViewControllerTests: XCTestCase {
     }
     
     func testHasExpectedNumberOfSections() {
-        XCTAssertEqual(3, viewController.numberOfSections(in: viewController.tableView))
-    }
-    
-    func testHasExpectedNumberOfSectionsWhenNoDisplayableTweakIsUngrouped() {
-        buildViewControllerWithConfigurationFromFileNamed("test_configuration_no_displayable_ungrouped")
         XCTAssertEqual(2, viewController.numberOfSections(in: viewController.tableView))
     }
     
-    func testUngroupedTweaksAreDisplayedUnderOneSection() {
-        XCTAssertEqual(4, viewController.tableView(viewController.tableView, numberOfRowsInSection: 2))
-        XCTAssertEqual("UI", viewController.tableView(viewController.tableView, titleForHeaderInSection: 2))
-    }
-    
     func testGroupedTweaksAreDisplayedInTheirOwnSections() {
-        XCTAssertEqual(1, viewController.tableView(viewController.tableView, numberOfRowsInSection: 0))
+        XCTAssertEqual(2, viewController.tableView(viewController.tableView, numberOfRowsInSection: 0))
         XCTAssertEqual("General", viewController.tableView(viewController.tableView, titleForHeaderInSection: 0))
-        XCTAssertEqual(1, viewController.tableView(viewController.tableView, numberOfRowsInSection: 1))
-        XCTAssertEqual("Other", viewController.tableView(viewController.tableView, titleForHeaderInSection: 1))
+        XCTAssertEqual(5, viewController.tableView(viewController.tableView, numberOfRowsInSection: 1))
+        XCTAssertEqual("UI Customization", viewController.tableView(viewController.tableView, titleForHeaderInSection: 1))
     }
     
     // MARK: Convenience Methods
     
     func testReturnsCorrectIndexPathForTweak_WhenTweakFound() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayYellowView.rawValue)
-        let expectedIndexPath = IndexPath(row: 2, section: 2)
+        let identifier = [Features.UICustomization.rawValue, Variables.DisplayYellowView.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)
+        let expectedIndexPath = IndexPath(row: 3, section: 1)
         XCTAssertEqual(indexPath, expectedIndexPath)
     }
     
     func testReturnsCorrectIndexPathForTweak_WhenTweakFound_2() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayRedView.rawValue)
-        let expectedIndexPath = IndexPath(row: 1, section: 2)
+        let identifier = [Features.UICustomization.rawValue, Variables.DisplayRedView.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)
+        let expectedIndexPath = IndexPath(row: 2, section: 1)
         XCTAssertEqual(indexPath, expectedIndexPath)
     }
     
     // MARK: Tweak Cells Display
     
     func testReturnsCorrectIndexPathForTweak_WhenTweakNotFound() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("some_nonexisting_tweak")
+        let identifier = [Features.General.rawValue, "some_nonexisting_tweak"].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)
         XCTAssertNil(indexPath)
     }
     
     func testDisplaysTweakOn_IfEnabled() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayYellowView.rawValue)!
+        let identifier = [Features.UICustomization.rawValue, Variables.DisplayYellowView.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath) as! BooleanTweakTableViewCell
         XCTAssertFalse(cell.switchControl.isOn)
     }
     
     func testDisplaysTweakOff_IfDisabled() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayRedView.rawValue)!
+        let identifier = [Features.UICustomization.rawValue, Variables.DisplayRedView.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath) as! BooleanTweakTableViewCell
         XCTAssertTrue(cell.switchControl.isOn)
     }
     
     func testDisplaysTweakTitle_ForTweakThatHaveIt() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayRedView.rawValue)!
+        let identifier = [Features.UICustomization.rawValue, Variables.DisplayRedView.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)
         XCTAssertEqual(cell.textLabel?.text, "Display Red View")
         XCTAssertEqual((cell as! TweaksConfigurationViewControllerCell).title, "Display Red View")
     }
     
-    func testDisplaysTweakIdentifier_ForTweakThatDoNotHaveATitle() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.TapToChangeViewColor.rawValue)!
-        let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)
-        XCTAssertEqual(cell.textLabel?.text, "tap_to_change_color_enabled")
-        XCTAssertEqual((cell as! TweaksConfigurationViewControllerCell).title, "tap_to_change_color_enabled")
-    }
-    
     func testDisplaysNumericTweaksCorrectly() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.RedViewAlpha.rawValue)!
+        let identifier = [Features.UICustomization.rawValue, Variables.RedViewAlpha.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath) as? NumericTweakTableViewCell
         XCTAssertEqual(cell?.title, "Red View Alpha Component")
         XCTAssertEqual(cell?.textField.text, "1.0")
     }
     
     func testDisplaysTextTweaksCorrectly() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.ChangeConfigurationButton.rawValue)!
+        let identifier = [Features.UICustomization.rawValue, Variables.ChangeConfigurationButton.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)  as? TextTweakTableViewCell
         XCTAssertEqual(cell?.title, "Change Tweaks Button Label Text")
         XCTAssertEqual(cell?.textField.text, "Change Configuration")
@@ -121,7 +112,8 @@ class ConfigurationViewControllerTests: XCTestCase {
         viewController.beginAppearanceTransition(true, animated: false)
         viewController.endAppearanceTransition()
         
-        let indexPath = viewController.indexPathForTweakWithIdentifier("display_yellow_view")!
+        let identifier = [Features.UICustomization.rawValue, Variables.DisplayYellowView.rawValue].joined(separator: "-")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(identifier)!
         let cell = viewController.tableView.cellForRow(at: indexPath) as! BooleanTweakTableViewCell
         cell.switchControl.isOn = true
         cell.switchControl.sendActions(for: .valueChanged)
@@ -188,9 +180,8 @@ class ConfigurationViewControllerTests: XCTestCase {
         let bundle = Bundle(for: ConfigurationViewControllerTests.self)
         let jsonURL = bundle.url(forResource: fileName, withExtension: "json")
         let jsonConfiguration = JSONTweaksConfiguration(defaultValuesFromJSONAtURL: jsonURL!)!
-        let userDefaults = UserDefaults(suiteName: "com.JustTweaks.Tests\(NSDate.timeIntervalSinceReferenceDate)")
-        let userDefaultsConfiguration = UserDefaultsTweaksConfiguration(userDefaults: userDefaults!,
-                                                                        fallbackConfiguration: jsonConfiguration)
+        let userDefaults = UserDefaults(suiteName: "com.JustTweaks.Tests\(NSDate.timeIntervalSinceReferenceDate)")!
+        let userDefaultsConfiguration = UserDefaultsTweaksConfiguration(userDefaults: userDefaults)
         let configurations: [TweaksConfiguration] = [jsonConfiguration, userDefaultsConfiguration]
         let configurationsCoordinator = TweaksConfigurationsCoordinator(configurations: configurations)!
         viewController = TweaksConfigurationViewController(style: .plain, configurationsCoordinator: configurationsCoordinator)

--- a/Example/Tests/UI/TweaksConfigurationViewControllerTests.swift
+++ b/Example/Tests/UI/TweaksConfigurationViewControllerTests.swift
@@ -125,7 +125,7 @@ class ConfigurationViewControllerTests: XCTestCase {
         let cell = viewController.tableView.cellForRow(at: indexPath) as! BooleanTweakTableViewCell
         cell.switchControl.isOn = true
         cell.switchControl.sendActions(for: .valueChanged)
-        XCTAssertTrue(viewController.configurationsCoordinator!.valueForTweakWith(identifier: "display_yellow_view") as! Bool)
+        XCTAssertTrue(viewController.configurationsCoordinator!.valueForTweakWith(feature: "display_yellow_view") as! Bool)
     }
     
     // MARK: No configuration view

--- a/Example/Tests/UI/TweaksConfigurationViewControllerTests.swift
+++ b/Example/Tests/UI/TweaksConfigurationViewControllerTests.swift
@@ -12,7 +12,7 @@ class ConfigurationViewControllerTests: XCTestCase {
     }
     
     override func tearDown() {
-        viewController.configurationsCoordinator?.topCustomizableConfiguration()?.deleteValue(forTweakWithIdentifier: "display_yellow_view")
+        viewController.configurationsCoordinator?.topCustomizableConfiguration()?.deleteValue(forTweakWithIdentifier: Variables.DisplayYellowView.rawValue)
         viewController = nil
         super.tearDown()
     }
@@ -56,13 +56,13 @@ class ConfigurationViewControllerTests: XCTestCase {
     // MARK: Convenience Methods
     
     func testReturnsCorrectIndexPathForTweak_WhenTweakFound() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("display_yellow_view")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayYellowView.rawValue)
         let expectedIndexPath = IndexPath(row: 2, section: 2)
         XCTAssertEqual(indexPath, expectedIndexPath)
     }
     
     func testReturnsCorrectIndexPathForTweak_WhenTweakFound_2() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("display_red_view")
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayRedView.rawValue)
         let expectedIndexPath = IndexPath(row: 1, section: 2)
         XCTAssertEqual(indexPath, expectedIndexPath)
     }
@@ -75,40 +75,40 @@ class ConfigurationViewControllerTests: XCTestCase {
     }
     
     func testDisplaysTweakOn_IfEnabled() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("display_yellow_view")!
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayYellowView.rawValue)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath) as! BooleanTweakTableViewCell
         XCTAssertFalse(cell.switchControl.isOn)
     }
     
     func testDisplaysTweakOff_IfDisabled() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("display_red_view")!
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayRedView.rawValue)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath) as! BooleanTweakTableViewCell
         XCTAssertTrue(cell.switchControl.isOn)
     }
     
     func testDisplaysTweakTitle_ForTweakThatHaveIt() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("display_red_view")!
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.DisplayRedView.rawValue)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)
         XCTAssertEqual(cell.textLabel?.text, "Display Red View")
         XCTAssertEqual((cell as! TweaksConfigurationViewControllerCell).title, "Display Red View")
     }
     
     func testDisplaysTweakIdentifier_ForTweakThatDoNotHaveATitle() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("tap_to_change_color_enabled")!
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.TapToChangeViewColor.rawValue)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)
         XCTAssertEqual(cell.textLabel?.text, "tap_to_change_color_enabled")
         XCTAssertEqual((cell as! TweaksConfigurationViewControllerCell).title, "tap_to_change_color_enabled")
     }
     
     func testDisplaysNumericTweaksCorrectly() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("red_view_alpha_component")!
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.RedViewAlpha.rawValue)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath) as? NumericTweakTableViewCell
         XCTAssertEqual(cell?.title, "Red View Alpha Component")
         XCTAssertEqual(cell?.textField.text, "1.0")
     }
     
     func testDisplaysTextTweaksCorrectly() {
-        let indexPath = viewController.indexPathForTweakWithIdentifier("change_tweaks_button_label_text")!
+        let indexPath = viewController.indexPathForTweakWithIdentifier(Variables.ChangeConfigurationButton.rawValue)!
         let cell = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)  as? TextTweakTableViewCell
         XCTAssertEqual(cell?.title, "Change Tweaks Button Label Text")
         XCTAssertEqual(cell?.textField.text, "Change Configuration")
@@ -125,7 +125,7 @@ class ConfigurationViewControllerTests: XCTestCase {
         let cell = viewController.tableView.cellForRow(at: indexPath) as! BooleanTweakTableViewCell
         cell.switchControl.isOn = true
         cell.switchControl.sendActions(for: .valueChanged)
-        XCTAssertTrue(viewController.configurationsCoordinator!.valueForTweakWith(feature: "display_yellow_view") as! Bool)
+        XCTAssertTrue(viewController.configurationsCoordinator!.valueForTweakWith(feature: Features.UICustomization.rawValue, variable: Variables.DisplayYellowView.rawValue) as! Bool)
     }
     
     // MARK: No configuration view

--- a/Example/Tests/test_configuration.json
+++ b/Example/Tests/test_configuration.json
@@ -1,39 +1,37 @@
 {
-    "display_red_view": {
+    "ui_customization-display_red_view": {
         "Title": "Display Red View",
-        "Group": "UI",
-        "Value": true,
-        "CanBeDisplayed": true
-    },
-    "display_yellow_view": {
-        "Title": "Display Yellow View",
-        "Group": "UI",
-        "Value": false,
-        "CanBeDisplayed": true
-    },
-    "display_green_view": {
+        "Group": "UI Customization",
         "Value": true
     },
-    "greet_on_app_did_become_active": {
-        "Title": "Greet on app launch",
-        "Group": "General",
-        "Value": false,
-        "CanBeDisplayed": true
+    "ui_customization-display_yellow_view": {
+        "Title": "Display Yellow View",
+        "Group": "UI Customization",
+        "Value": false
     },
-    "tap_to_change_color_enabled": {
-        "Value": true,
-        "CanBeDisplayed": true
+    "ui_customization-display_green_view": {
+        "Title": "Display Green View",
+        "Group": "UI Customization",
+        "Value": true
     },
-    "red_view_alpha_component": {
-        "CanBeDisplayed": true,
+    "ui_customization-red_view_alpha_component": {
         "Title": "Red View Alpha Component",
-        "Group": "UI",
+        "Group": "UI Customization",
         "Value": 1.0
     },
-    "change_tweaks_button_label_text": {
-        "CanBeDisplayed": true,
+    "ui_customization-change_tweaks_button_label_text": {
         "Title": "Change Tweaks Button Label Text",
-        "Group": "UI",
+        "Group": "UI Customization",
         "Value": "Change Configuration"
+    },
+    "general-greet_on_app_did_become_active": {
+        "Title": "Greet on app launch",
+        "Group": "General",
+        "Value": false
+    },
+    "general-tap_to_change_color_enabled": {
+        "Title": "Tap to change views color",
+        "Group": "General",
+        "Value": true
     }
 }

--- a/Example/Tests/test_configuration.json
+++ b/Example/Tests/test_configuration.json
@@ -24,9 +24,6 @@
         "Value": true,
         "CanBeDisplayed": true
     },
-    "tap_to_change_color_enabled_bis": {
-        "CanBeDisplayed": false
-    },
     "red_view_alpha_component": {
         "CanBeDisplayed": true,
         "Title": "Red View Alpha Component",

--- a/Example/Tests/test_configuration_no_displayable_ungrouped.json
+++ b/Example/Tests/test_configuration_no_displayable_ungrouped.json
@@ -1,27 +1,27 @@
 {
-    "display_red_view": {
+    "ui_customization-display_red_view": {
         "Title": "Display Red View",
-        "Group": "UI",
-        "Value": true,
-        "CanBeDisplayed": true
-    },
-    "display_yellow_view": {
-        "Title": "Display Yellow View",
-        "Group": "UI",
-        "Value": false,
-        "CanBeDisplayed": true
-    },
-    "display_green_view": {
+        "Group": "UI Customization",
         "Value": true
     },
-    "greet_on_app_did_become_active": {
+    "ui_customization-display_yellow_view": {
+        "Title": "Display Yellow View",
+        "Group": "UI Customization",
+        "Value": false
+    },
+    "ui_customization-display_green_view": {
+        "Title": "Display Green View",
+        "Group": "UI Customization",
+        "Value": true
+    },
+    "general-greet_on_app_did_become_active": {
         "Title": "Greet on app launch",
         "Group": "General",
-        "Value": false,
-        "CanBeDisplayed": true
+        "Value": false
     },
-    "tap_to_change_color_enabled": {
-        "Value": true,
-        "Title": "Tap to change views color"
+    "general-tap_to_change_color_enabled": {
+        "Title": "Tap to change views color",
+        "Group": "General",
+        "Value": true
     }
 }

--- a/JustTweak/Classes/Core/EphemeralConfiguration.swift
+++ b/JustTweak/Classes/Core/EphemeralConfiguration.swift
@@ -19,8 +19,12 @@ import Foundation
     }
     
     public func tweakWith(feature: String) -> Tweak? {
-        guard let storedValue = storage[feature] else { return nil }
-        return Tweak(identifier: feature, title: nil, group: nil, value: storedValue, canBeDisplayed: false)
+        return tweakWith(feature: "", variable: feature)
+    }
+    
+    public func tweakWith(feature: String, variable: String) -> Tweak? {
+        guard let storedValue = storage[variable] else { return nil }
+        return Tweak(identifier: variable, title: nil, group: nil, value: storedValue, canBeDisplayed: false)
     }
     
     public func deleteValue(forTweakWithIdentifier identifier: String) {

--- a/JustTweak/Classes/Core/EphemeralConfiguration.swift
+++ b/JustTweak/Classes/Core/EphemeralConfiguration.swift
@@ -10,9 +10,7 @@ import Foundation
     private var storage = [String : TweakValue]()
     public var logClosure: TweaksLogClosure?
     
-    public var priority: TweaksConfigurationPriority {
-        return .fallback
-    }
+    public var priority: TweaksConfigurationPriority = .p1
     
     public var allTweakIdentifiers: [String] {
         return Array(storage.keys)

--- a/JustTweak/Classes/Core/EphemeralConfiguration.swift
+++ b/JustTweak/Classes/Core/EphemeralConfiguration.swift
@@ -25,6 +25,10 @@ import Foundation
         return Tweak(identifier: variable, title: nil, group: nil, value: storedValue, canBeDisplayed: false)
     }
     
+    public func activeVariation(for experiment: String) -> String? {
+        return nil
+    }
+
     public func deleteValue(forTweakWithIdentifier identifier: String) {
         storage.removeValue(forKey: identifier)
     }
@@ -39,6 +43,5 @@ import Foundation
     
     public func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String) {
         storage[identifier] = value.tweakValue
-    }
-    
+    }    
 }

--- a/JustTweak/Classes/Core/EphemeralConfiguration.swift
+++ b/JustTweak/Classes/Core/EphemeralConfiguration.swift
@@ -5,43 +5,39 @@
 
 import Foundation
 
-@objcMembers public class EphemeralConfiguration: NSObject, MutableTweaksConfiguration {
+public class EphemeralConfiguration: NSObject, MutableTweaksConfiguration {
     
-    private var storage = [String : TweakValue]()
+    private var storage = [String : [String : TweakValue]]()
     public var logClosure: TweaksLogClosure?
     
     public var priority: TweaksConfigurationPriority = .p1
     
-    public var allTweakIdentifiers: [String] {
-        return Array(storage.keys)
-    }
-    
     public func isFeatureEnabled(_ feature: String) -> Bool {
-        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
+        return false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard let storedValue = storage[variable] else { return nil }
-        return Tweak(identifier: variable, title: nil, group: nil, value: storedValue, canBeDisplayed: false)
+        guard let storedValue = storage[feature]?[variable] else { return nil }
+        return Tweak(identifier: variable, title: nil, group: nil, value: storedValue)
     }
     
     public func activeVariation(for experiment: String) -> String? {
         return nil
     }
 
-    public func deleteValue(forTweakWithIdentifier identifier: String) {
-        storage.removeValue(forKey: identifier)
+    public func deleteValue(feature: String, variable: String) {
+        storage[feature]?.removeValue(forKey: variable)
     }
     
-    public func set(boolValue value: Bool, forTweakWithIdentifier identifier: String) {
-        set(numberValue: NSNumber(value: value), forTweakWithIdentifier: identifier)
+    public func set(_ value: Bool, feature: String, variable: String) {
+        storage[feature]?[variable] = NSNumber(value: value).tweakValue
     }
     
-    public func set(stringValue value: String, forTweakWithIdentifier identifier: String) {
-        storage[identifier] = value
+    public func set(_ value: String, feature: String, variable: String) {
+        storage[feature]?[variable] = value
     }
     
-    public func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String) {
-        storage[identifier] = value.tweakValue
-    }    
+    public func set(_ value: NSNumber, feature: String, variable: String) {
+        storage[feature]?[variable] = value.tweakValue
+    }
 }

--- a/JustTweak/Classes/Core/EphemeralConfiguration.swift
+++ b/JustTweak/Classes/Core/EphemeralConfiguration.swift
@@ -16,8 +16,8 @@ import Foundation
         return Array(storage.keys)
     }
     
-    public func tweakWith(feature: String) -> Tweak? {
-        return tweakWith(feature: "", variable: feature)
+    public func isFeatureEnabled(_ feature: String) -> Bool {
+        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {

--- a/JustTweak/Classes/Core/EphemeralConfiguration.swift
+++ b/JustTweak/Classes/Core/EphemeralConfiguration.swift
@@ -18,9 +18,9 @@ import Foundation
         return Array(storage.keys)
     }
     
-    public func tweakWith(identifier: String) -> Tweak? {
-        guard let storedValue = storage[identifier] else { return nil }
-        return Tweak(identifier: identifier, title: nil, group: nil, value: storedValue, canBeDisplayed: false)
+    public func tweakWith(feature: String) -> Tweak? {
+        guard let storedValue = storage[feature] else { return nil }
+        return Tweak(identifier: feature, title: nil, group: nil, value: storedValue, canBeDisplayed: false)
     }
     
     public func deleteValue(forTweakWithIdentifier identifier: String) {

--- a/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
@@ -35,8 +35,8 @@ import Foundation
         fileURL = jsonURL
     }
     
-    public func tweakWith(feature: String) -> Tweak? {
-        return tweakWith(feature: "", variable: feature)
+    public func isFeatureEnabled(_ feature: String) -> Bool {
+        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {

--- a/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
@@ -36,12 +36,16 @@ import Foundation
     }
     
     public func tweakWith(feature: String) -> Tweak? {
-        guard let dictionary = configurationFile[feature] else { return nil }
+        return tweakWith(feature: "", variable: feature)
+    }
+    
+    public func tweakWith(feature: String, variable: String) -> Tweak? {
+        guard let dictionary = configurationFile[variable] else { return nil }
         let title = dictionary[EncodingKeys.Title.rawValue] as? String
         let group = dictionary[EncodingKeys.Group.rawValue] as? String
         let value = tweakValueFromJSONObject(dictionary[EncodingKeys.Value.rawValue])
         let canBeDisplayed = dictionary[EncodingKeys.CanBeDisplayed.rawValue]?.boolValue ?? false
-        return Tweak(identifier: feature,
+        return Tweak(identifier: variable,
                      title: title,
                      group: group,
                      value: value,

--- a/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
@@ -35,13 +35,13 @@ import Foundation
         fileURL = jsonURL
     }
     
-    public func tweakWith(identifier: String) -> Tweak? {
-        guard let dictionary = configurationFile[identifier] else { return nil }
+    public func tweakWith(feature: String) -> Tweak? {
+        guard let dictionary = configurationFile[feature] else { return nil }
         let title = dictionary[EncodingKeys.Title.rawValue] as? String
         let group = dictionary[EncodingKeys.Group.rawValue] as? String
         let value = tweakValueFromJSONObject(dictionary[EncodingKeys.Value.rawValue])
         let canBeDisplayed = dictionary[EncodingKeys.CanBeDisplayed.rawValue]?.boolValue ?? false
-        return Tweak(identifier: identifier,
+        return Tweak(identifier: feature,
                      title: title,
                      group: group,
                      value: value,

--- a/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
@@ -15,7 +15,7 @@ import Foundation
     private let fileURL: URL
     
     public var logClosure: TweaksLogClosure?
-    public let priority: TweaksConfigurationPriority = .fallback
+    public let priority: TweaksConfigurationPriority = .p0
     
     public var allIdentifiers: [String] {
         return Array(configurationFile.keys)

--- a/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/JSONTweaksConfiguration.swift
@@ -52,6 +52,10 @@ import Foundation
                      canBeDisplayed: canBeDisplayed)
     }
     
+    public func activeVariation(for experiment: String) -> String? {
+        return nil
+    }
+
     private func tweakValueFromJSONObject(_ jsonObject: AnyObject?) -> TweakValue {
         let value: TweakValue
         if let numberValue = jsonObject as? NSNumber {
@@ -65,5 +69,4 @@ import Foundation
         }
         return value
     }
-    
 }

--- a/JustTweak/Classes/Core/Tweak.swift
+++ b/JustTweak/Classes/Core/Tweak.swift
@@ -48,14 +48,13 @@ public func ==(lhs: TweakValue, rhs: TweakValue) -> Bool {
     return NSNumber(tweakValue: lhs) == NSNumber(tweakValue: rhs)
 }
 
-@objcMembers final public class Tweak: NSObject {
+final public class Tweak: NSObject {
     
     public let identifier: String
     public let value: TweakValue
     
     public let title: String?
     public let group: String?
-    public let canBeDisplayed: Bool
     
     public var displayTitle: String {
         return title ?? identifier
@@ -77,8 +76,7 @@ public func ==(lhs: TweakValue, rhs: TweakValue) -> Bool {
             return ["title": title,
                     "group": group,
                     "value": value,
-                    "identifier": identifier,
-                    "canBeDisplayed": canBeDisplayed]
+                    "identifier": identifier]
         }
     }
     public override var description: String {
@@ -87,8 +85,7 @@ public func ==(lhs: TweakValue, rhs: TweakValue) -> Bool {
         }
     }
     
-    public init(identifier: String, title: String?, group: String?, value: TweakValue, canBeDisplayed: Bool) {
-        self.canBeDisplayed = canBeDisplayed
+    public init(identifier: String, title: String?, group: String?, value: TweakValue) {
         self.identifier = identifier
         self.value = value
         self.title = title
@@ -100,43 +97,42 @@ public func ==(lhs: TweakValue, rhs: TweakValue) -> Bool {
         return lhs.identifier == rhs.identifier &&
             lhs.value == rhs.value &&
             lhs.title == rhs.title &&
-            lhs.group == rhs.group &&
-            lhs.canBeDisplayed == rhs.canBeDisplayed
+            lhs.group == rhs.group
     }
     
 }
 
 // Objective-C support
 public extension Tweak {
-    @objc public var intValue: Int {
+    public var intValue: Int {
         return value.intValue
     }
     
-    @objc public var floatValue: Float {
+    public var floatValue: Float {
         return value.floatValue
     }
     
-    @objc public var doubleValue: Double {
+    public var doubleValue: Double {
         return value.doubleValue
     }
     
-    @objc public var boolValue: Bool {
+    public var boolValue: Bool {
         return value.boolValue
     }
     
-    @objc public var stringValue: String? {
+    public var stringValue: String? {
         return value.stringValue
     }
     
     convenience init(identifier: String, boolValue: Bool) {
-        self.init(identifier: identifier, title: nil, group: nil, value: boolValue, canBeDisplayed: false)
+        self.init(identifier: identifier, title: nil, group: nil, value: boolValue)
     }
     
     convenience init(identifier: String, stringValue: String) {
-        self.init(identifier: identifier, title: nil, group: nil, value: stringValue, canBeDisplayed: false)
+        self.init(identifier: identifier, title: nil, group: nil, value: stringValue)
     }
     
     convenience init(identifier: String, numberValue: NSNumber) {
-        self.init(identifier: identifier, title: nil, group: nil, value: numberValue.tweakValue, canBeDisplayed: false)
+        self.init(identifier: identifier, title: nil, group: nil, value: numberValue.tweakValue)
     }
 }

--- a/JustTweak/Classes/Core/Tweak.swift
+++ b/JustTweak/Classes/Core/Tweak.swift
@@ -5,49 +5,6 @@
 
 import Foundation
 
-public protocol TweakValue: CustomStringConvertible {}
-
-extension Bool: TweakValue {}
-extension Int: TweakValue {}
-extension Float: TweakValue {}
-extension Double: TweakValue {}
-extension String: TweakValue {
-    public var description: String {
-        get { return self }
-    }
-}
-
-public extension TweakValue {
-    
-    public var intValue: Int {
-        return Int(doubleValue)
-    }
-    
-    public var floatValue: Float {
-        return Float(doubleValue)
-    }
-    
-    public var doubleValue: Double {
-        return Double(description) ?? 0.0
-    }
-    
-    public var boolValue: Bool {
-        return self as? Bool ?? false
-    }
-    
-    public var stringValue: String? {
-        return self as? String
-    }
-    
-}
-
-public func ==(lhs: TweakValue, rhs: TweakValue) -> Bool {
-    if let lhs = lhs as? String, let rhs = rhs as? String {
-        return lhs == rhs
-    }
-    return NSNumber(tweakValue: lhs) == NSNumber(tweakValue: rhs)
-}
-
 final public class Tweak: NSObject {
     
     public let identifier: String
@@ -102,7 +59,6 @@ final public class Tweak: NSObject {
     
 }
 
-// Objective-C support
 public extension Tweak {
     public var intValue: Int {
         return value.intValue

--- a/JustTweak/Classes/Core/TweakValue.swift
+++ b/JustTweak/Classes/Core/TweakValue.swift
@@ -1,0 +1,49 @@
+//
+//  TweakValue.swift
+//  Copyright (c) 2016 Just Eat Holding Ltd. All rights reserved.
+//
+
+import Foundation
+
+public protocol TweakValue: CustomStringConvertible {}
+
+extension Bool: TweakValue {}
+extension Int: TweakValue {}
+extension Float: TweakValue {}
+extension Double: TweakValue {}
+extension String: TweakValue {
+    public var description: String {
+        get { return self }
+    }
+}
+
+public extension TweakValue {
+    
+    public var intValue: Int {
+        return Int(doubleValue)
+    }
+    
+    public var floatValue: Float {
+        return Float(doubleValue)
+    }
+    
+    public var doubleValue: Double {
+        return Double(description) ?? 0.0
+    }
+    
+    public var boolValue: Bool {
+        return self as? Bool ?? false
+    }
+    
+    public var stringValue: String? {
+        return self as? String
+    }
+    
+}
+
+public func ==(lhs: TweakValue, rhs: TweakValue) -> Bool {
+    if let lhs = lhs as? String, let rhs = rhs as? String {
+        return lhs == rhs
+    }
+    return NSNumber(tweakValue: lhs) == NSNumber(tweakValue: rhs)
+}

--- a/JustTweak/Classes/Core/TweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/TweaksConfiguration.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 @objc public enum TweaksConfigurationPriority: Int {
-    case high, medium, low, fallback
+    case p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10
 }
 
 @objc public protocol TweaksConfiguration {

--- a/JustTweak/Classes/Core/TweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/TweaksConfiguration.swift
@@ -15,6 +15,7 @@ import Foundation
     var priority: TweaksConfigurationPriority { get }
     func isFeatureEnabled(_ feature: String) -> Bool
     func tweakWith(feature: String, variable: String) -> Tweak?
+    func activeVariation(for experiment: String) -> String?
 }
 
 @objc public protocol MutableTweaksConfiguration: TweaksConfiguration {

--- a/JustTweak/Classes/Core/TweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/TweaksConfiguration.swift
@@ -13,7 +13,7 @@ import Foundation
     
     var logClosure: TweaksLogClosure? { set get }
     var priority: TweaksConfigurationPriority { get }
-    func tweakWith(identifier: String) -> Tweak?
+    func tweakWith(feature: String) -> Tweak?
     
 }
 

--- a/JustTweak/Classes/Core/TweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/TweaksConfiguration.swift
@@ -14,7 +14,7 @@ import Foundation
     var logClosure: TweaksLogClosure? { set get }
     var priority: TweaksConfigurationPriority { get }
     func tweakWith(feature: String) -> Tweak?
-    
+    func tweakWith(feature: String, variable: String) -> Tweak?
 }
 
 @objc public protocol MutableTweaksConfiguration: TweaksConfiguration {

--- a/JustTweak/Classes/Core/TweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/TweaksConfiguration.swift
@@ -5,40 +5,39 @@
 
 import Foundation
 
-@objc public enum TweaksConfigurationPriority: Int {
+public enum TweaksConfigurationPriority: Int {
     case p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10
 }
 
-@objc public protocol TweaksConfiguration {
+public protocol TweaksConfiguration {
     
     var logClosure: TweaksLogClosure? { set get }
     var priority: TweaksConfigurationPriority { get }
+    
     func isFeatureEnabled(_ feature: String) -> Bool
     func tweakWith(feature: String, variable: String) -> Tweak?
     func activeVariation(for experiment: String) -> String?
 }
 
-@objc public protocol MutableTweaksConfiguration: TweaksConfiguration {
+public protocol MutableTweaksConfiguration: TweaksConfiguration {
     
-    var allTweakIdentifiers: [String] { get }
-    
-    func deleteValue(forTweakWithIdentifier identifier: String)
-    func set(boolValue value: Bool, forTweakWithIdentifier identifier: String)
-    func set(stringValue value: String, forTweakWithIdentifier identifier: String)
-    func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String)
+    func deleteValue(feature: String, variable: String)
+    func set(_ value: Bool, feature: String, variable: String)
+    func set(_ value: String, feature: String, variable: String)
+    func set(_ value: NSNumber, feature: String, variable: String)
 }
 
 public extension MutableTweaksConfiguration {
     
-    func set(value: TweakValue, forTweakWithIdentifier identifier: String) {
+    func set(value: TweakValue, feature: String, variable: String) {
         if let value = value as? Bool {
-            set(boolValue: value, forTweakWithIdentifier: identifier)
+            set(value, feature: feature, variable: variable)
         }
         if let value = value as? String {
-            set(stringValue: value, forTweakWithIdentifier: identifier)
+            set(value, feature: feature, variable: variable)
         }
         else if let value = NSNumber(tweakValue: value) {
-            set(numberValue: value, forTweakWithIdentifier: identifier)
+            set(value, feature: feature, variable: variable)
         }
     }
 }

--- a/JustTweak/Classes/Core/TweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/TweaksConfiguration.swift
@@ -13,7 +13,7 @@ import Foundation
     
     var logClosure: TweaksLogClosure? { set get }
     var priority: TweaksConfigurationPriority { get }
-    func tweakWith(feature: String) -> Tweak?
+    func isFeatureEnabled(_ feature: String) -> Bool
     func tweakWith(feature: String, variable: String) -> Tweak?
 }
 
@@ -25,7 +25,6 @@ import Foundation
     func set(boolValue value: Bool, forTweakWithIdentifier identifier: String)
     func set(stringValue value: String, forTweakWithIdentifier identifier: String)
     func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String)
-    
 }
 
 public extension MutableTweaksConfiguration {
@@ -41,7 +40,6 @@ public extension MutableTweaksConfiguration {
             set(numberValue: value, forTweakWithIdentifier: identifier)
         }
     }
-    
 }
 
 public let TweaksConfigurationDidChangeNotification = Notification.Name("TweaksConfigurationDidChangeNotification")

--- a/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
+++ b/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
@@ -49,8 +49,8 @@ import Foundation
         NotificationCenter.default.removeObserver(self)
     }
     
-    public func tweakWith(feature: String) -> Tweak? {
-        if let cachedValue = tweaksCache[feature] {
+    public func tweakWith(feature: String, variable: String) -> Tweak? {
+        if let cachedValue = tweaksCache[variable] {
             logClosure("Tweak '\(cachedValue.tweak)' found in cache.)", .verbose)
             return cachedValue.tweak
         }
@@ -58,32 +58,32 @@ import Foundation
         var result: Tweak? = nil
         var valueSource: String? = nil
         for (_, configuration) in configurations.enumerated() {
-            if let tweak = configuration.tweakWith(feature: feature) {
+            if let tweak = configuration.tweakWith(feature: feature, variable: variable) {
                 logClosure("Tweak '\(tweak)' found in configuration \(configuration))", .verbose)
                 valueSource = valueSource ?? "\(type(of: configuration))"
-                result = Tweak(identifier: feature,
+                result = Tweak(identifier: variable,
                                title: result?.title ?! tweak.title,
                                group: result?.group ?! tweak.group,
                                value: result?.value ?! tweak.value,
                                canBeDisplayed: result?.canBeDisplayed ||| tweak.canBeDisplayed) // always displayable if any configuration allows it
             }
             else {
-                logClosure("Tweak with identifier '\(feature)' NOT found in configuration \(configuration))", .verbose)
+                logClosure("Tweak with identifier '\(variable)' NOT found in configuration \(configuration))", .verbose)
             }
         }
         if let result = result, let valueSource = valueSource {
-            logClosure("Tweak with identifier '\(feature)' resolved. Using '\(result)'.", .debug)
+            logClosure("Tweak with identifier '\(variable)' resolved. Using '\(result)'.", .debug)
             let cachedValue = TweakCachedValue(tweak: result, source: valueSource)
-            tweaksCache[feature] = cachedValue
+            tweaksCache[variable] = cachedValue
         }
         else {
-            logClosure("No Tweak found for identifier '\(feature)'", .error)
+            logClosure("No Tweak found for identifier '\(variable)'", .error)
         }
         return result
     }
     
-    public func valueForTweakWith(feature: String) -> TweakValue? {
-        return tweakWith(feature: feature)?.value
+    public func valueForTweakWith(feature: String, variable: String) -> TweakValue? {
+        return tweakWith(feature: feature, variable: variable)?.value
     }
     
     public func topCustomizableConfiguration() -> MutableTweaksConfiguration? {
@@ -98,8 +98,8 @@ import Foundation
     public func displayableTweaks() -> [Tweak] {
         var allTweaks = [Tweak]()
         if let allTweakIdentifiers = topCustomizableConfiguration()?.allTweakIdentifiers {
-            for identfier in allTweakIdentifiers {
-                if let tweak = tweakWith(feature: identfier) , tweak.canBeDisplayed {
+            for identifier in allTweakIdentifiers {
+                if let tweak = tweakWith(feature: "", variable: identifier), tweak.canBeDisplayed {
                     allTweaks.append(tweak)
                 }
             }

--- a/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
+++ b/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
@@ -49,8 +49,8 @@ import Foundation
         NotificationCenter.default.removeObserver(self)
     }
     
-    public func tweakWith(identifier: String) -> Tweak? {
-        if let cachedValue = tweaksCache[identifier] {
+    public func tweakWith(feature: String) -> Tweak? {
+        if let cachedValue = tweaksCache[feature] {
             logClosure("Tweak '\(cachedValue.tweak)' found in cache.)", .verbose)
             return cachedValue.tweak
         }
@@ -58,32 +58,32 @@ import Foundation
         var result: Tweak? = nil
         var valueSource: String? = nil
         for (_, configuration) in configurations.enumerated() {
-            if let tweak = configuration.tweakWith(identifier: identifier) {
+            if let tweak = configuration.tweakWith(feature: feature) {
                 logClosure("Tweak '\(tweak)' found in configuration \(configuration))", .verbose)
                 valueSource = valueSource ?? "\(type(of: configuration))"
-                result = Tweak(identifier: identifier,
+                result = Tweak(identifier: feature,
                                title: result?.title ?! tweak.title,
                                group: result?.group ?! tweak.group,
                                value: result?.value ?! tweak.value,
                                canBeDisplayed: result?.canBeDisplayed ||| tweak.canBeDisplayed) // always displayable if any configuration allows it
             }
             else {
-                logClosure("Tweak with identifier '\(identifier)' NOT found in configuration \(configuration))", .verbose)
+                logClosure("Tweak with identifier '\(feature)' NOT found in configuration \(configuration))", .verbose)
             }
         }
         if let result = result, let valueSource = valueSource {
-            logClosure("Tweak with identifier '\(identifier)' resolved. Using '\(result)'.", .debug)
+            logClosure("Tweak with identifier '\(feature)' resolved. Using '\(result)'.", .debug)
             let cachedValue = TweakCachedValue(tweak: result, source: valueSource)
-            tweaksCache[identifier] = cachedValue
+            tweaksCache[feature] = cachedValue
         }
         else {
-            logClosure("No Tweak found for identifier '\(identifier)'", .error)
+            logClosure("No Tweak found for identifier '\(feature)'", .error)
         }
         return result
     }
     
-    public func valueForTweakWith(identifier: String) -> TweakValue? {
-        return tweakWith(identifier: identifier)?.value
+    public func valueForTweakWith(feature: String) -> TweakValue? {
+        return tweakWith(feature: feature)?.value
     }
     
     public func topCustomizableConfiguration() -> MutableTweaksConfiguration? {
@@ -99,7 +99,7 @@ import Foundation
         var allTweaks = [Tweak]()
         if let allTweakIdentifiers = topCustomizableConfiguration()?.allTweakIdentifiers {
             for identfier in allTweakIdentifiers {
-                if let tweak = tweakWith(identifier: identfier) , tweak.canBeDisplayed {
+                if let tweak = tweakWith(feature: identfier) , tweak.canBeDisplayed {
                     allTweaks.append(tweak)
                 }
             }

--- a/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
+++ b/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
@@ -35,7 +35,7 @@ import Foundation
     
     public init?(configurations: [TweaksConfiguration]) {
         guard configurations.count > 0 else { return nil }
-        self.configurations = configurations.sorted(by: { $0.priority.rawValue < $1.priority.rawValue })
+        self.configurations = configurations.sorted(by: { $0.priority.rawValue > $1.priority.rawValue })
         logClosure("Configurations lookup order => \(self.configurations) ", .verbose)
         super.init()
         self.configurations.forEach {

--- a/JustTweak/Classes/Core/TweaksUtitlities.swift
+++ b/JustTweak/Classes/Core/TweaksUtitlities.swift
@@ -30,7 +30,7 @@ public func |||(lhs: Bool?, rhs: Bool?) -> Bool {
     return rhs ?? false
 }
 
-@objc public enum TweaksLogLevel: Int {
+public enum TweaksLogLevel: Int {
     case error, debug, verbose
 }
 

--- a/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
@@ -5,10 +5,9 @@
 
 import Foundation
 
-@objcMembers final public class UserDefaultsTweaksConfiguration: NSObject, MutableTweaksConfiguration {
+final public class UserDefaultsTweaksConfiguration: NSObject, MutableTweaksConfiguration {
     
     private let userDefaults: UserDefaults
-    private let fallbackConfiguration: JSONTweaksConfiguration?
     private var registeredTweaksIdentifiers: Set<String> = Set<String>()
     
     private static let userDefaultsKeyPrefix = "lib.fragments.userDefaultsKey"
@@ -16,50 +15,48 @@ import Foundation
     public var logClosure: TweaksLogClosure?
     public let priority: TweaksConfigurationPriority = .p10
     
-    public var allTweakIdentifiers: [String] {
-        let fallbackConfigurationTweaks = fallbackConfiguration?.allIdentifiers ?? []
-        registeredTweaksIdentifiers.formUnion(fallbackConfigurationTweaks)
-        return Array(registeredTweaksIdentifiers).sorted()
-    }
-    
-    public init(userDefaults: UserDefaults, fallbackConfiguration: JSONTweaksConfiguration? = nil) {
+    public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
-        self.fallbackConfiguration = fallbackConfiguration
     }
     
     public func isFeatureEnabled(_ feature: String) -> Bool {
-        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
+        return false
     }
 
     public func tweakWith(feature: String, variable: String) -> Tweak? {
-        let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(variable)
-        let fallbackTweak = fallbackConfiguration?.tweakWith(feature: feature, variable: variable)
+        let identifier = [feature, variable].joined(separator: "-")
+        let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(identifier)
         let userDefaultsValue = userDefaults.object(forKey: userDefaultsKey)
         guard let value = tweakValueFromUserDefaultsObject(userDefaultsValue as AnyObject?) else { return nil }
-        return Tweak(identifier: variable,
-                     title: fallbackTweak?.title,
-                     group: fallbackTweak?.group,
-                     value: value,
-                     canBeDisplayed: fallbackTweak?.canBeDisplayed ?? false)
+        return Tweak(identifier: identifier,
+                     title: nil,
+                     group: nil,
+                     value: value)
     }
     
     public func activeVariation(for experiment: String) -> String? {
         return nil
     }
 
-    public func set(boolValue value: Bool, forTweakWithIdentifier identifier: String) {
-        set(numberValue: NSNumber(value: value as Bool), forTweakWithIdentifier: identifier)
+    public func deleteValue(feature: String, variable: String) {
+        let identifier = [feature, variable].joined(separator: "-")
+        userDefaults.removeObject(forKey: userDefaultsKeyForTweakWithIdentifier(identifier))
     }
     
-    public func set(stringValue value: String, forTweakWithIdentifier identifier: String) {
-        updateUserDefaultsWith(value: value as AnyObject, forTweakWithIdentifier: identifier)
+    public func set(_ value: Bool, feature: String, variable: String) {
+        updateUserDefaultsWith(value: value, feature: feature, variable: variable)
     }
     
-    public func set(numberValue value: NSNumber, forTweakWithIdentifier identifier: String) {
-        updateUserDefaultsWith(value: value, forTweakWithIdentifier: identifier)
+    public func set(_ value: String, feature: String, variable: String) {
+        updateUserDefaultsWith(value: value, feature: feature, variable: variable)
     }
     
-    private func updateUserDefaultsWith(value: AnyObject, forTweakWithIdentifier identifier: String) {
+    public func set(_ value: NSNumber, feature: String, variable: String) {
+        updateUserDefaultsWith(value: value, feature: feature, variable: variable)
+    }
+    
+    private func updateUserDefaultsWith(value: Any, feature: String, variable: String) {
+        let identifier = [feature, variable].joined(separator: "-")
         registeredTweaksIdentifiers.insert(identifier)
         userDefaults.set(value, forKey: userDefaultsKeyForTweakWithIdentifier(identifier))
         userDefaults.synchronize()
@@ -68,10 +65,6 @@ import Foundation
         notificationCenter.post(name: TweaksConfigurationDidChangeNotification,
                                 object: self,
                                 userInfo: userInfo)
-    }
-    
-    public func deleteValue(forTweakWithIdentifier identifier: String) {
-        userDefaults.removeObject(forKey: userDefaultsKeyForTweakWithIdentifier(identifier))
     }
     
     private func userDefaultsKeyForTweakWithIdentifier(_ identifier: String) -> String {

--- a/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
@@ -27,12 +27,12 @@ import Foundation
         self.fallbackConfiguration = fallbackConfiguration
     }
     
-    public func tweakWith(identifier: String) -> Tweak? {
-        let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(identifier)
-        let fallbackTweak = fallbackConfiguration?.tweakWith(identifier: identifier)
+    public func tweakWith(feature: String) -> Tweak? {
+        let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(feature)
+        let fallbackTweak = fallbackConfiguration?.tweakWith(feature: feature)
         let userDefaultsValue = userDefaults.object(forKey: userDefaultsKey)
         guard let value = tweakValueFromUserDefaultsObject(userDefaultsValue as AnyObject?) else { return nil }
-        return Tweak(identifier: identifier,
+        return Tweak(identifier: feature,
                      title: fallbackTweak?.title,
                      group: fallbackTweak?.group,
                      value: value,

--- a/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
@@ -27,13 +27,13 @@ import Foundation
         self.fallbackConfiguration = fallbackConfiguration
     }
     
-    public func tweakWith(feature: String) -> Tweak? {
-        return tweakWith(feature: "", variable: feature)
+    public func isFeatureEnabled(_ feature: String) -> Bool {
+        return tweakWith(feature: "", variable: feature)?.boolValue ?? false
     }
-    
+
     public func tweakWith(feature: String, variable: String) -> Tweak? {
         let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(variable)
-        let fallbackTweak = fallbackConfiguration?.tweakWith(feature: variable)
+        let fallbackTweak = fallbackConfiguration?.tweakWith(feature: feature, variable: variable)
         let userDefaultsValue = userDefaults.object(forKey: userDefaultsKey)
         guard let value = tweakValueFromUserDefaultsObject(userDefaultsValue as AnyObject?) else { return nil }
         return Tweak(identifier: variable,

--- a/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
@@ -43,6 +43,10 @@ import Foundation
                      canBeDisplayed: fallbackTweak?.canBeDisplayed ?? false)
     }
     
+    public func activeVariation(for experiment: String) -> String? {
+        return nil
+    }
+
     public func set(boolValue value: Bool, forTweakWithIdentifier identifier: String) {
         set(numberValue: NSNumber(value: value as Bool), forTweakWithIdentifier: identifier)
     }
@@ -83,5 +87,4 @@ import Foundation
         }
         return nil
     }
-    
 }

--- a/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
@@ -14,7 +14,7 @@ import Foundation
     private static let userDefaultsKeyPrefix = "lib.fragments.userDefaultsKey"
     
     public var logClosure: TweaksLogClosure?
-    public let priority: TweaksConfigurationPriority = .high
+    public let priority: TweaksConfigurationPriority = .p10
     
     public var allTweakIdentifiers: [String] {
         let fallbackConfigurationTweaks = fallbackConfiguration?.allIdentifiers ?? []

--- a/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
+++ b/JustTweak/Classes/Core/UserDefaultsTweaksConfiguration.swift
@@ -28,11 +28,15 @@ import Foundation
     }
     
     public func tweakWith(feature: String) -> Tweak? {
-        let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(feature)
-        let fallbackTweak = fallbackConfiguration?.tweakWith(feature: feature)
+        return tweakWith(feature: "", variable: feature)
+    }
+    
+    public func tweakWith(feature: String, variable: String) -> Tweak? {
+        let userDefaultsKey = userDefaultsKeyForTweakWithIdentifier(variable)
+        let fallbackTweak = fallbackConfiguration?.tweakWith(feature: variable)
         let userDefaultsValue = userDefaults.object(forKey: userDefaultsKey)
         guard let value = tweakValueFromUserDefaultsObject(userDefaultsValue as AnyObject?) else { return nil }
-        return Tweak(identifier: feature,
+        return Tweak(identifier: variable,
                      title: fallbackTweak?.title,
                      group: fallbackTweak?.group,
                      value: value,

--- a/JustTweak/Classes/UI/TweaksConfigurationViewController.swift
+++ b/JustTweak/Classes/UI/TweaksConfigurationViewController.swift
@@ -8,14 +8,14 @@ import UIKit
 internal protocol TweaksConfigurationViewControllerCell: class {
     var title: String? { get set }
     var value: TweakValue { get set }
-    weak var delegate: TweaksConfigurationViewControllerCellDelegate? { get set }
+    var delegate: TweaksConfigurationViewControllerCellDelegate? { get set }
 }
 
 internal protocol TweaksConfigurationViewControllerCellDelegate: class {
     func tweaksConfigurationCellDidChangeValue(_ cell: TweaksConfigurationViewControllerCell)
 }
 
-@objcMembers public class TweaksConfigurationViewController: UITableViewController {
+public class TweaksConfigurationViewController: UITableViewController {
     
     fileprivate class Tweak: NSObject {
         var identifier: String
@@ -205,7 +205,6 @@ internal protocol TweaksConfigurationViewControllerCellDelegate: class {
         view.endEditing(true)
         presentingViewController?.dismiss(animated: true, completion: nil)
     }
-    
 }
 
 extension TweaksConfigurationViewController: TweaksConfigurationViewControllerCellDelegate {
@@ -214,10 +213,12 @@ extension TweaksConfigurationViewController: TweaksConfigurationViewControllerCe
         if let indexPath = tableView.indexPath(for: cell as! UITableViewCell) {
             if let tweak = tweakAt(indexPath: indexPath) {
                 let configuration = configurationsCoordinator?.topCustomizableConfiguration()
-                configuration?.set(value: cell.value, forTweakWithIdentifier: tweak.identifier)
+                let components = tweak.identifier.split(separator: "-")
+                let feature = String(components[0])
+                let variable = String(components[1])
+                configuration?.set(value: cell.value, feature: feature, variable: variable)
                 tweak.value = cell.value
             }
         }
     }
-    
 }


### PR DESCRIPTION
This PR is part of the [V3 milestone](https://github.com/justeat/JustTweak/milestone/1). V3 PRs should be merged into [`feature/version-3`](https://github.com/justeat/JustTweak/tree/feature/version-3).

It includes support for [Optimizely](https://www.optimizely.com/) as well as wide refactoring and improvements across the codebase. Changes are self-contained but there will be more refactoring and polishing to come in subsequent PRs.

Main changes:

- [x] Experiment (w/ variations) and features (w/ variables) are now reflected as first class citizens in JustTweak to support Optimizely lingo.
- [x] Add `OptimizelyTweaksConfiguration` in demo project
- [x] Remove `Tweak`'s `canBeDisplayed` property
- [x] Remove fallbackConfiguration from `UserDefaultsTweaksConfiguration`
- [x] Add features property to `JSONTweaksConfiguration`
- [x] Simplify logic to fetch tweaks from the coordinator (avoid iterating through all the configurations)
- [x] `TweaksConfigurationsViewController` shows only the tweaks from the `JSONTweaksConfiguration` (but overridden values if any)
- [x] Simplify methods in `MutableTweaksConfiguration`
- [x] Remove `allTweakIdentifiers` from `MutableTweaksConfiguration`
- [x] Remove `@objc` and `@objcMembers` across the whole codebase.
- [x] Update tests

authors: @dchakarov, @albertodebortoli 