### PR TITLE
Update dependencies and tweak the log level when no tweak is found

### DIFF
--- a/Example/JustTweak/Configurations/FirebaseTweaksConfiguration.swift
+++ b/Example/JustTweak/Configurations/FirebaseTweaksConfiguration.swift
@@ -37,14 +37,14 @@ public class FirebaseTweaksConfiguration: NSObject, TweaksConfiguration {
     
     private func fetchTweaks() {
         guard configured else { return }
-        remoteConfiguration.configSettings = RemoteConfigSettings(developerModeEnabled: true)
+        remoteConfiguration.configSettings = RemoteConfigSettings()
         remoteConfiguration.fetch { [weak self] (status, error) in
             guard let strongSelf = self else { return }
             if let error = error {
                 strongSelf.logClosure?("Error while fetching Firebase configuration => \(error)", .error)
             }
             else {
-                self?.remoteConfiguration.activateFetched()
+                self?.remoteConfiguration.activate(completionHandler: nil) // You can pass a completion handler if you want the configuration to be applied immediately after being fetched; otherwise it will be applied on next launch
                 let notificationCentre = NotificationCenter.default
                 notificationCentre.post(name: TweaksConfigurationDidChangeNotification, object: self)
             }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,37 +1,37 @@
 PODS:
-  - Firebase/CoreOnly (6.2.0):
-    - FirebaseCore (= 6.0.2)
-  - Firebase/RemoteConfig (6.2.0):
+  - Firebase/CoreOnly (6.3.0):
+    - FirebaseCore (= 6.0.3)
+  - Firebase/RemoteConfig (6.3.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 4.0.0)
+    - FirebaseRemoteConfig (~> 4.1.0)
   - FirebaseABTesting (3.0.0):
     - FirebaseCore (~> 6.0)
     - Protobuf (~> 3.5)
-  - FirebaseCore (6.0.2):
+  - FirebaseCore (6.0.3):
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/Logger (~> 6.0)
-  - FirebaseInstanceID (4.1.1):
+  - FirebaseInstanceID (4.2.0):
     - FirebaseCore (~> 6.0)
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/UserDefaults (~> 6.0)
-  - FirebaseRemoteConfig (4.0.0):
+  - FirebaseRemoteConfig (4.1.0):
     - FirebaseABTesting (~> 3.0)
     - FirebaseCore (~> 6.0)
-    - FirebaseInstanceID (~> 4.0)
+    - FirebaseInstanceID (~> 4.2)
     - GoogleUtilities/Environment (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - Protobuf (~> 3.5)
-  - GoogleUtilities/Environment (6.2.0)
-  - GoogleUtilities/Logger (6.2.0):
+  - GoogleUtilities/Environment (6.2.1)
+  - GoogleUtilities/Logger (6.2.1):
     - GoogleUtilities/Environment
-  - "GoogleUtilities/NSData+zlib (6.2.0)"
-  - GoogleUtilities/UserDefaults (6.2.0):
+  - "GoogleUtilities/NSData+zlib (6.2.1)"
+  - GoogleUtilities/UserDefaults (6.2.1):
     - GoogleUtilities/Logger
-  - JustTweak (3.5.0):
-    - JustTweak/Core (= 3.5.0)
-    - JustTweak/UI (= 3.5.0)
-  - JustTweak/Core (3.5.0)
-  - JustTweak/UI (3.5.0):
+  - JustTweak (3.5.1):
+    - JustTweak/Core (= 3.5.1)
+    - JustTweak/UI (= 3.5.1)
+  - JustTweak/Core (3.5.1)
+  - JustTweak/UI (3.5.1):
     - JustTweak/Core
   - OptimizelySDKCore (3.1.1)
   - OptimizelySDKDatafileManager (3.1.1):
@@ -74,13 +74,13 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Firebase: 5965bac23e7fcb5fa6d926ed429c9ecef8a2014e
+  Firebase: 8432d732974498afd5987e9001a05f90f1a3d625
   FirebaseABTesting: a32c488eb75089a61eb3d86db061dfb909d765db
-  FirebaseCore: b0f0262acebfa540e5f97b3832dbb13186980822
-  FirebaseInstanceID: cdb3827746d53ece7ae87a5c51c25c3055443366
-  FirebaseRemoteConfig: 40f75c6ea20a52bf65ef44e3898910dd5b57c532
-  GoogleUtilities: 996e0db07153674fd1b54b220fda3a3dc3547cba
-  JustTweak: dba66d4c7869684181b6ce4439dbed11d2ddb5df
+  FirebaseCore: 68f8a7f50cdae542715d4e86afa37c4067217dcb
+  FirebaseInstanceID: f20243a1d828e0e9a3798b995174dedc16f1b32a
+  FirebaseRemoteConfig: 7c64ecec5ca63d7c6b304509c3a6f9a036d403d4
+  GoogleUtilities: c7a0b08bda3bf808be823ed151f0e28ac6866e71
+  JustTweak: e3902b2bfe2fe9acf387022f1c8724eb23d3b192
   OptimizelySDKCore: 18bda61dedb38b642b2856d971d1ed2f102cacee
   OptimizelySDKDatafileManager: f8c998425e0cbdc7270647e3bff7fe0b07df9172
   OptimizelySDKEventDispatcher: 08f5d2e0eca4a2d265da9137d0dc077c26e8d369

--- a/JustTweak.podspec
+++ b/JustTweak.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustTweak'
-  s.version          = '3.5.0'
+  s.version          = '3.5.1'
   s.summary          = 'A framework for feature flagging, locally and remotely configure and A/B test iOS apps.'
   s.description      = <<-DESC
 JustTweak is a framework for feature flagging, locally and remotely configure and A/B test iOS apps.

--- a/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
+++ b/JustTweak/Classes/Core/TweaksConfigurationsCoordinator.swift
@@ -79,7 +79,7 @@ final public class TweaksConfigurationsCoordinator: NSObject, TweaksConfiguratio
             }
         }
         else {
-            logClosure?("No Tweak found for identifier '\(variable)'", .error)
+            logClosure?("No Tweak found for identifier '\(variable)'", .verbose)
         }
         return result
     }


### PR DESCRIPTION
- Change the logging level when no tweak is found for a key from error to verbose, as `nil` is a valid return value
- Update the example FirebaseTweaksConfiguration to reflect the updates in FirebaseRemoteConfig