### PR TITLE
Atomic properties in TweakManager

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -43,7 +43,7 @@ PODS:
   - "GoogleUtilities/NSData+zlib (6.3.1)"
   - GoogleUtilities/UserDefaults (6.3.1):
     - GoogleUtilities/Logger
-  - JustTweak (5.1.0)
+  - JustTweak (5.1.3)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -107,7 +107,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
   GoogleDataTransportCCTSupport: f6ab1962e9dc05ab1fb938b795e5b310209edeec
   GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
-  JustTweak: 3a28a066b86a1b082cf14685ba7ffdd33b30dd85
+  JustTweak: 22268d223f16a6c89fb64d62d2a0d32aa262cd4d
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   OptimizelySDKCore: 3f6018cc222b23de13ae9a71c2c15cd7fa397aed
   OptimizelySDKDatafileManager: 34edeb189ef170992677149460172ef44bfa7250

--- a/JustTweak.podspec
+++ b/JustTweak.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name                    = 'JustTweak'
-  s.version                 = '5.1.2'
+  s.version                 = '5.1.3'
   s.summary                 = 'A framework for feature flagging, locally and remotely configure and A/B test iOS apps.'
   s.description             = <<-DESC
 JustTweak is a framework for feature flagging, locally and remotely configure and A/B test iOS apps.

--- a/JustTweak/Classes/Configurations/UserDefaultsConfiguration.swift
+++ b/JustTweak/Classes/Configurations/UserDefaultsConfiguration.swift
@@ -70,11 +70,13 @@ extension UserDefaultsConfiguration {
         
     private func updateUserDefaults(value: TweakValue, feature: String, variable: String) {
         userDefaults.set(value, forKey: keyForTweakWithIdentifier(variable))
-        let notificationCenter = NotificationCenter.default
-        let tweak = Tweak(feature: feature, variable: variable, value: value)
-        let userInfo = [TweakConfigurationDidChangeNotificationTweakKey: tweak]
-        notificationCenter.post(name: TweakConfigurationDidChangeNotification,
-                                object: self,
-                                userInfo: userInfo)
+        DispatchQueue.main.async {
+            let notificationCenter = NotificationCenter.default
+            let tweak = Tweak(feature: feature, variable: variable, value: value)
+            let userInfo = [TweakConfigurationDidChangeNotificationTweakKey: tweak]
+            notificationCenter.post(name: TweakConfigurationDidChangeNotification,
+                                    object: self,
+                                    userInfo: userInfo)
+        }
     }
 }

--- a/JustTweak/Classes/TweakManager.swift
+++ b/JustTweak/Classes/TweakManager.swift
@@ -25,12 +25,10 @@ final public class TweakManager {
         }
     }
     
-    private let queue = DispatchQueue(label: "com.justeat.tweakManager")
-    
-    private var featureCache = [String : Bool]()
-    private var tweakCache = [String : [String : Tweak]]()
-    private var experimentCache = [String : String]()
-    private var observersMap = [NSObject : NSObjectProtocol]()
+    @Atomic private var featureCache = [String : Bool]()
+    @Atomic private var tweakCache = [String : [String : Tweak]]()
+    @Atomic private var experimentCache = [String : String]()
+    @Atomic private var observersMap = [NSObject : NSObjectProtocol]()
     
     var mutableConfiguration: MutableConfiguration? {
         return configurations.first { $0 is MutableConfiguration } as? MutableConfiguration
@@ -53,103 +51,96 @@ final public class TweakManager {
 extension TweakManager: MutableConfiguration {
     
     public func isFeatureEnabled(_ feature: String) -> Bool {
-        queue.sync {
-            if useCache, let cachedFeature = featureCache[feature] {
-                logClosure?("Feature '\(cachedFeature)' found in cache.)", .verbose)
-                return cachedFeature
-            }
-            
-            var enabled = false
-            for (_, configuration) in configurations.enumerated() {
-                if configuration.isFeatureEnabled(feature) {
-                    enabled = true
-                    break
-                }
-            }
-            if useCache {
-                featureCache[feature] = enabled
-            }
-            return enabled
+        if useCache, let cachedFeature = featureCache[feature] {
+            logClosure?("Feature '\(cachedFeature)' found in cache.)", .verbose)
+            return cachedFeature
         }
+        
+        var enabled = false
+        for (_, configuration) in configurations.enumerated() {
+            if configuration.isFeatureEnabled(feature) {
+                enabled = true
+                break
+            }
+        }
+        if useCache {
+            _featureCache.mutate { $0[feature] = enabled }
+        }
+        return enabled
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {
-        queue.sync {
-            if useCache, let cachedTweaks = tweakCache[feature], let cachedTweak = cachedTweaks[variable] {
-                logClosure?("Tweak '\(cachedTweak)' found in cache.)", .verbose)
-                return cachedTweak
-            }
-            
-            var result: Tweak? = nil
-            for (_, configuration) in configurations.enumerated() {
-                if let tweak = configuration.tweakWith(feature: feature, variable: variable) {
-                    logClosure?("Tweak '\(tweak)' found in configuration \(configuration))", .verbose)
-                    result = Tweak(feature: feature,
-                                   variable: variable,
-                                   value: tweak.value,
-                                   title: tweak.title,
-                                   group: tweak.group,
-                                   source: "\(type(of: configuration))")
-                    break
-                }
-                else {
-                    logClosure?("Tweak with identifier '\(variable)' NOT found in configuration \(configuration))", .verbose)
-                }
-            }
-            if let result = result {
-                logClosure?("Tweak with feature '\(feature)' and variable '\(variable)' resolved. Using '\(result)'.", .debug)
-                if useCache {
-                    if let _ = tweakCache[feature] {
-                        tweakCache[feature]?[variable] = result
-                    } else {
-                        tweakCache[feature] = [variable : result]
-                    }
-                }
+        if useCache,
+            let cachedTweaks = tweakCache[feature],
+            let cachedTweak = cachedTweaks[variable] {
+            logClosure?("Tweak '\(cachedTweak)' found in cache.)", .verbose)
+            return cachedTweak
+        }
+        
+        var result: Tweak? = nil
+        for (_, configuration) in configurations.enumerated() {
+            if let tweak = configuration.tweakWith(feature: feature, variable: variable) {
+                logClosure?("Tweak '\(tweak)' found in configuration \(configuration))", .verbose)
+                result = Tweak(feature: feature,
+                               variable: variable,
+                               value: tweak.value,
+                               title: tweak.title,
+                               group: tweak.group,
+                               source: "\(type(of: configuration))")
+                break
             }
             else {
-                logClosure?("No Tweak found for identifier '\(variable)'", .verbose)
+                logClosure?("Tweak with identifier '\(variable)' NOT found in configuration \(configuration))", .verbose)
             }
-            return result
         }
+        if let result = result {
+            logClosure?("Tweak with feature '\(feature)' and variable '\(variable)' resolved. Using '\(result)'.", .debug)
+            if useCache {
+                if let _ = tweakCache[feature] {
+                    _tweakCache.mutate { $0[feature]?[variable] = result }
+                } else {
+                    _tweakCache.mutate { $0[feature] = [variable : result] }
+                }
+            }
+        }
+        else {
+            logClosure?("No Tweak found for identifier '\(variable)'", .verbose)
+        }
+        return result
     }
     
     public func activeVariation(for experiment: String) -> String? {
-        queue.sync {
-            if useCache, let cachedExperiment = experimentCache[experiment] {
-                logClosure?("Experiment '\(cachedExperiment)' found in cache.)", .verbose)
-                return cachedExperiment
-            }
-            
-            var activeVariation: String?
-            for (_, configuration) in configurations.enumerated() {
-                activeVariation = configuration.activeVariation(for: experiment)
-                if activeVariation != nil { break }
-            }
-            if useCache {
-                experimentCache[experiment] = activeVariation
-            }
-            return activeVariation
+        if useCache, let cachedExperiment = experimentCache[experiment] {
+            logClosure?("Experiment '\(cachedExperiment)' found in cache.)", .verbose)
+            return cachedExperiment
         }
+        
+        var activeVariation: String? = nil
+        for (_, configuration) in configurations.enumerated() {
+            activeVariation = configuration.activeVariation(for: experiment)
+            if activeVariation != nil { break }
+        }
+        if useCache {
+            _experimentCache.mutate { $0[experiment] = activeVariation }
+            experimentCache[experiment] = activeVariation
+        }
+        return activeVariation
     }
     
     public func set(_ value: TweakValue, feature: String, variable: String) {
         guard let mutableConfiguration = self.mutableConfiguration else { return }
         if useCache {
-            queue.sync {
-                // cannot use write-through cache because tweakWith(feature:variable:) returns a Tweak, but here we only have a TweakValue
-                // we simply set the entry to nil so the next fetch will go through the list of configurations and subsequently re-cache
-                tweakCache[feature]?[variable] = nil
-            }
+            // cannot use write-through cache because tweakWith(feature:variable:) returns a Tweak, but here we only have a TweakValue
+            // we simply set the entry to nil so the next fetch will go through the list of configurations and subsequently re-cache
+            _tweakCache.mutate { $0[feature]?[variable] = nil }
         }
         mutableConfiguration.set(value, feature: feature, variable: variable)
     }
-
+    
     public func deleteValue(feature: String, variable: String) {
         guard let mutableConfiguration = self.mutableConfiguration else { return }
         if useCache {
-            queue.sync {
-                tweakCache[feature]?[variable] = nil
-            }
+            _tweakCache.mutate { $0[feature]?[variable] = nil }
         }
         mutableConfiguration.deleteValue(feature: feature, variable: variable)
     }
@@ -158,25 +149,21 @@ extension TweakManager: MutableConfiguration {
 extension TweakManager {
     
     public func registerForConfigurationsUpdates(_ object: NSObject, closure: @escaping (Tweak) -> Void) {
-        self.deregisterFromConfigurationsUpdates(object)
-        queue.sync {
-            let queue = OperationQueue.main
-            let name = TweakConfigurationDidChangeNotification
-            let notificationsCenter = NotificationCenter.default
-            let observer = notificationsCenter.addObserver(forName: name, object: nil, queue: queue) { notification in
-                guard let tweak = notification.userInfo?[TweakConfigurationDidChangeNotificationTweakKey] as? Tweak else { return }
-                closure(tweak)
-            }
-            observersMap[object] = observer
+        deregisterFromConfigurationsUpdates(object)
+        let queue = OperationQueue.main
+        let name = TweakConfigurationDidChangeNotification
+        let notificationsCenter = NotificationCenter.default
+        let observer = notificationsCenter.addObserver(forName: name, object: nil, queue: queue) { notification in
+            guard let tweak = notification.userInfo?[TweakConfigurationDidChangeNotificationTweakKey] as? Tweak else { return }
+            closure(tweak)
         }
+        _observersMap.mutate { $0[object] = observer }
     }
     
     public func deregisterFromConfigurationsUpdates(_ object: NSObject) {
-        queue.sync {
-            guard let observer = observersMap[object] else { return }
-            NotificationCenter.default.removeObserver(observer)
-            observersMap.removeValue(forKey: object)
-        }
+        guard let observer = observersMap[object] else { return }
+        NotificationCenter.default.removeObserver(observer)
+        _observersMap.mutate { $0.removeValue(forKey: object) }
     }
     
     @objc private func configurationDidChange() {
@@ -189,10 +176,8 @@ extension TweakManager {
 extension TweakManager {
     
     public func resetCache() {
-        queue.sync {
-            featureCache = [String : Bool]()
-            tweakCache = [String : [String : Tweak]]()
-            experimentCache = [String : String]()
-        }
+        _featureCache.mutate { $0.removeAll() }
+        _tweakCache.mutate { $0.removeAll() }
+        _experimentCache.mutate { $0.removeAll() }
     }
 }


### PR DESCRIPTION
This PR addresses the following:

- [x] Dispatch asynchronously the posting of `TweakConfigurationDidChangeNotification` from `UserDefaultsConfiguration`
- [x] Remove the serial queue from `TweakManager` (de facto making the class not thread-safe anymore)
- [x] Add the `Atomic` property wrapper
- [x] Mark some `TweakManager`'s properties as `Atomic` to make them thread-safe

We feel this implementation is better than the previous one where `TweakManager` was made thread-safe. Consumers of JustTweak could implement custom configurations that could fire off `TweakConfigurationDidChangeNotification` notifications and this would cause a deadlock with the changes introduced with #42 but later workarounded with #43. Having only the properties to be thread-safe keeps the code 1. easier to read, 2. extendable, and 3. avoids making `TweakManager` unnecessarily thread-safe.