### PR TITLE
Rollback to thread safe class implementation

### DIFF
--- a/JustTweak.podspec
+++ b/JustTweak.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name                    = 'JustTweak'
-  s.version                 = '5.1.3'
+  s.version                 = '5.1.4'
   s.summary                 = 'A framework for feature flagging, locally and remotely configure and A/B test iOS apps.'
   s.description             = <<-DESC
 JustTweak is a framework for feature flagging, locally and remotely configure and A/B test iOS apps.

--- a/JustTweak/Classes/TweakManager.swift
+++ b/JustTweak/Classes/TweakManager.swift
@@ -25,10 +25,12 @@ final public class TweakManager {
         }
     }
     
-    @Atomic private var featureCache = [String : Bool]()
-    @Atomic private var tweakCache = [String : [String : Tweak]]()
-    @Atomic private var experimentCache = [String : String]()
-    @Atomic private var observersMap = [NSObject : NSObjectProtocol]()
+    private let queue = DispatchQueue(label: "com.justeat.tweakManager")
+    
+    private var featureCache = [String : Bool]()
+    private var tweakCache = [String : [String : Tweak]]()
+    private var experimentCache = [String : String]()
+    private var observersMap = [NSObject : NSObjectProtocol]()
     
     var mutableConfiguration: MutableConfiguration? {
         return configurations.first { $0 is MutableConfiguration } as? MutableConfiguration
@@ -51,96 +53,103 @@ final public class TweakManager {
 extension TweakManager: MutableConfiguration {
     
     public func isFeatureEnabled(_ feature: String) -> Bool {
-        if useCache, let cachedFeature = featureCache[feature] {
-            logClosure?("Feature '\(cachedFeature)' found in cache.)", .verbose)
-            return cachedFeature
-        }
-        
-        var enabled = false
-        for (_, configuration) in configurations.enumerated() {
-            if configuration.isFeatureEnabled(feature) {
-                enabled = true
-                break
+        queue.sync {
+            if useCache, let cachedFeature = featureCache[feature] {
+                logClosure?("Feature '\(cachedFeature)' found in cache.)", .verbose)
+                return cachedFeature
             }
+            
+            var enabled = false
+            for (_, configuration) in configurations.enumerated() {
+                if configuration.isFeatureEnabled(feature) {
+                    enabled = true
+                    break
+                }
+            }
+            if useCache {
+                featureCache[feature] = enabled
+            }
+            return enabled
         }
-        if useCache {
-            _featureCache.mutate { $0[feature] = enabled }
-        }
-        return enabled
     }
     
     public func tweakWith(feature: String, variable: String) -> Tweak? {
-        if useCache,
-            let cachedTweaks = tweakCache[feature],
-            let cachedTweak = cachedTweaks[variable] {
-            logClosure?("Tweak '\(cachedTweak)' found in cache.)", .verbose)
-            return cachedTweak
-        }
-        
-        var result: Tweak? = nil
-        for (_, configuration) in configurations.enumerated() {
-            if let tweak = configuration.tweakWith(feature: feature, variable: variable) {
-                logClosure?("Tweak '\(tweak)' found in configuration \(configuration))", .verbose)
-                result = Tweak(feature: feature,
-                               variable: variable,
-                               value: tweak.value,
-                               title: tweak.title,
-                               group: tweak.group,
-                               source: "\(type(of: configuration))")
-                break
+        queue.sync {
+            if useCache, let cachedTweaks = tweakCache[feature], let cachedTweak = cachedTweaks[variable] {
+                logClosure?("Tweak '\(cachedTweak)' found in cache.)", .verbose)
+                return cachedTweak
             }
-            else {
-                logClosure?("Tweak with identifier '\(variable)' NOT found in configuration \(configuration))", .verbose)
-            }
-        }
-        if let result = result {
-            logClosure?("Tweak with feature '\(feature)' and variable '\(variable)' resolved. Using '\(result)'.", .debug)
-            if useCache {
-                if let _ = tweakCache[feature] {
-                    _tweakCache.mutate { $0[feature]?[variable] = result }
-                } else {
-                    _tweakCache.mutate { $0[feature] = [variable : result] }
+            
+            var result: Tweak? = nil
+            for (_, configuration) in configurations.enumerated() {
+                if let tweak = configuration.tweakWith(feature: feature, variable: variable) {
+                    logClosure?("Tweak '\(tweak)' found in configuration \(configuration))", .verbose)
+                    result = Tweak(feature: feature,
+                                   variable: variable,
+                                   value: tweak.value,
+                                   title: tweak.title,
+                                   group: tweak.group,
+                                   source: "\(type(of: configuration))")
+                    break
+                }
+                else {
+                    logClosure?("Tweak with identifier '\(variable)' NOT found in configuration \(configuration))", .verbose)
                 }
             }
+            if let result = result {
+                logClosure?("Tweak with feature '\(feature)' and variable '\(variable)' resolved. Using '\(result)'.", .debug)
+                if useCache {
+                    if let _ = tweakCache[feature] {
+                        tweakCache[feature]?[variable] = result
+                    } else {
+                        tweakCache[feature] = [variable : result]
+                    }
+                }
+            }
+            else {
+                logClosure?("No Tweak found for identifier '\(variable)'", .verbose)
+            }
+            return result
         }
-        else {
-            logClosure?("No Tweak found for identifier '\(variable)'", .verbose)
-        }
-        return result
     }
     
     public func activeVariation(for experiment: String) -> String? {
-        if useCache, let cachedExperiment = experimentCache[experiment] {
-            logClosure?("Experiment '\(cachedExperiment)' found in cache.)", .verbose)
-            return cachedExperiment
+        queue.sync {
+            if useCache, let cachedExperiment = experimentCache[experiment] {
+                logClosure?("Experiment '\(cachedExperiment)' found in cache.)", .verbose)
+                return cachedExperiment
+            }
+            
+            var activeVariation: String?
+            for (_, configuration) in configurations.enumerated() {
+                activeVariation = configuration.activeVariation(for: experiment)
+                if activeVariation != nil { break }
+            }
+            if useCache {
+                experimentCache[experiment] = activeVariation
+            }
+            return activeVariation
         }
-        
-        var activeVariation: String? = nil
-        for (_, configuration) in configurations.enumerated() {
-            activeVariation = configuration.activeVariation(for: experiment)
-            if activeVariation != nil { break }
-        }
-        if useCache {
-            _experimentCache.mutate { $0[experiment] = activeVariation }
-            experimentCache[experiment] = activeVariation
-        }
-        return activeVariation
     }
     
     public func set(_ value: TweakValue, feature: String, variable: String) {
         guard let mutableConfiguration = self.mutableConfiguration else { return }
         if useCache {
-            // cannot use write-through cache because tweakWith(feature:variable:) returns a Tweak, but here we only have a TweakValue
-            // we simply set the entry to nil so the next fetch will go through the list of configurations and subsequently re-cache
-            _tweakCache.mutate { $0[feature]?[variable] = nil }
+            queue.sync {
+                // cannot use write-through cache because tweakWith(feature:variable:) returns a Tweak, but here we only have a TweakValue
+                // we simply set the entry to nil so the next fetch will go through the list of configurations and subsequently re-cache
+                tweakCache[feature]?[variable] = nil
+            }
         }
         mutableConfiguration.set(value, feature: feature, variable: variable)
     }
-    
+
     public func deleteValue(feature: String, variable: String) {
         guard let mutableConfiguration = self.mutableConfiguration else { return }
         if useCache {
-            _tweakCache.mutate { $0[feature]?[variable] = nil }
+            queue.sync {
+                tweakCache[feature]?[variable] = nil
+            }
         }
         mutableConfiguration.deleteValue(feature: feature, variable: variable)
     }
@@ -149,21 +158,25 @@ extension TweakManager: MutableConfiguration {
 extension TweakManager {
     
     public func registerForConfigurationsUpdates(_ object: NSObject, closure: @escaping (Tweak) -> Void) {
-        deregisterFromConfigurationsUpdates(object)
-        let queue = OperationQueue.main
-        let name = TweakConfigurationDidChangeNotification
-        let notificationsCenter = NotificationCenter.default
-        let observer = notificationsCenter.addObserver(forName: name, object: nil, queue: queue) { notification in
-            guard let tweak = notification.userInfo?[TweakConfigurationDidChangeNotificationTweakKey] as? Tweak else { return }
-            closure(tweak)
+        self.deregisterFromConfigurationsUpdates(object)
+        queue.sync {
+            let queue = OperationQueue.main
+            let name = TweakConfigurationDidChangeNotification
+            let notificationsCenter = NotificationCenter.default
+            let observer = notificationsCenter.addObserver(forName: name, object: nil, queue: queue) { notification in
+                guard let tweak = notification.userInfo?[TweakConfigurationDidChangeNotificationTweakKey] as? Tweak else { return }
+                closure(tweak)
+            }
+            observersMap[object] = observer
         }
-        _observersMap.mutate { $0[object] = observer }
     }
     
     public func deregisterFromConfigurationsUpdates(_ object: NSObject) {
-        guard let observer = observersMap[object] else { return }
-        NotificationCenter.default.removeObserver(observer)
-        _observersMap.mutate { $0.removeValue(forKey: object) }
+        queue.sync {
+            guard let observer = observersMap[object] else { return }
+            NotificationCenter.default.removeObserver(observer)
+            observersMap.removeValue(forKey: object)
+        }
     }
     
     @objc private func configurationDidChange() {
@@ -176,8 +189,10 @@ extension TweakManager {
 extension TweakManager {
     
     public func resetCache() {
-        _featureCache.mutate { $0.removeAll() }
-        _tweakCache.mutate { $0.removeAll() }
-        _experimentCache.mutate { $0.removeAll() }
+        queue.sync {
+            featureCache = [String : Bool]()
+            tweakCache = [String : [String : Tweak]]()
+            experimentCache = [String : String]()
+        }
     }
 }

--- a/JustTweak/Classes/Utilities/PropertyWrappers.swift
+++ b/JustTweak/Classes/Utilities/PropertyWrappers.swift
@@ -59,29 +59,3 @@ public struct OptionalTweakProperty<T: TweakValue> {
         }
     }
 }
-
-@propertyWrapper
-struct Atomic<Value> {
-
-    let queue = DispatchQueue(label: "com.justeat.AtomicPropertyWrapper", attributes: .concurrent)
-    var value: Value
-
-    init(wrappedValue: Value) {
-        self.value = wrappedValue
-    }
-
-    var wrappedValue: Value {
-        get {
-            return queue.sync { value }
-        }
-        set {
-            queue.sync(flags: .barrier) { value = newValue }
-        }
-    }
-
-    mutating func mutate(_ mutation: (inout Value) throws -> Void) rethrows {
-        try queue.sync(flags: .barrier) {
-            try mutation(&value)
-        }
-    }
-}


### PR DESCRIPTION
This PR rolls back to the previous fix to the threading issue that we're experiencing.
This solution is the same adopted in 5.1.2 version.

The version in bumped to 5.1.4.