### PR TITLE
Support for multiple local configurations

### DIFF
--- a/Example/JustTweak.xcodeproj/project.pbxproj
+++ b/Example/JustTweak.xcodeproj/project.pbxproj
@@ -568,7 +568,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -618,7 +618,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -634,7 +634,6 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustTweak.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -649,7 +648,6 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustTweak.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -668,7 +666,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JustTweak_Example.app/JustTweak_Example";
 			};
 			name = Debug;
@@ -683,7 +680,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JustTweak_Example.app/JustTweak_Example";
 			};
 			name = Release;

--- a/Example/JustTweak.xcodeproj/project.pbxproj
+++ b/Example/JustTweak.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		4F30EA6F21ADA06A00AECF77 /* OptimizelyConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F30EA6C21ADA06A00AECF77 /* OptimizelyConfiguration.swift */; };
 		4F38E0EF236DF6E20070BD17 /* ConfigurationAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E0EE236DF6E20070BD17 /* ConfigurationAccessor.swift */; };
 		4F38E0F1236E1BB60070BD17 /* PropertyWrappersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E0F0236E1BB60070BD17 /* PropertyWrappersTests.swift */; };
+		4F43583223E732DD00FD60A7 /* TweakManager+PresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F43583123E732DD00FD60A7 /* TweakManager+PresentationTests.swift */; };
+		4F43583423E7332D00FD60A7 /* test_configuration_override.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F43583323E7332D00FD60A7 /* test_configuration_override.json */; };
 		4F6422A321A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */; };
 		4F6422A621A4205B002B69F0 /* Symbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6422A521A4205B002B69F0 /* Symbols.swift */; };
 		4F6422A721A4205B002B69F0 /* Symbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6422A521A4205B002B69F0 /* Symbols.swift */; };
@@ -58,6 +60,8 @@
 		4F30EA6C21ADA06A00AECF77 /* OptimizelyConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptimizelyConfiguration.swift; sourceTree = "<group>"; };
 		4F38E0EE236DF6E20070BD17 /* ConfigurationAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAccessor.swift; sourceTree = "<group>"; };
 		4F38E0F0236E1BB60070BD17 /* PropertyWrappersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyWrappersTests.swift; sourceTree = "<group>"; };
+		4F43583123E732DD00FD60A7 /* TweakManager+PresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TweakManager+PresentationTests.swift"; sourceTree = "<group>"; };
+		4F43583323E7332D00FD60A7 /* test_configuration_override.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = test_configuration_override.json; sourceTree = "<group>"; };
 		4F6422A221A2FF8A002B69F0 /* ExampleOptimizelyDatafile.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ExampleOptimizelyDatafile.json; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.javascript; };
 		4F6422A521A4205B002B69F0 /* Symbols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Symbols.swift; sourceTree = "<group>"; };
 		4F7103ED23859CFD0021E4AF /* CustomOperators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomOperators.swift; sourceTree = "<group>"; };
@@ -197,6 +201,7 @@
 				619938E11DA8061900765852 /* test_configuration_invalid.json */,
 				619938DD1DA7F9FA00765852 /* test_configuration_no_displayable_ungrouped.json */,
 				61A5613F1DA7B64900839F7F /* test_configuration.json */,
+				4F43583323E7332D00FD60A7 /* test_configuration_override.json */,
 				607FACEA1AFB9204008FA782 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -227,6 +232,7 @@
 				619938DF1DA805BA00765852 /* LocalConfigurationTests.swift */,
 				618A46CB1DAD481400B8F5CA /* TweakExtensionsTests.swift */,
 				61F1DEC91DA7ECD300314DEC /* TweakManagerTests.swift */,
+				4F43583123E732DD00FD60A7 /* TweakManager+PresentationTests.swift */,
 				4F0372B12387FE79003CA58E /* TweakManagerCacheTests.swift */,
 				61F1DECD1DA7ECF700314DEC /* TweaksUtilitiesTests.swift */,
 				619938D71DA7F2DA00765852 /* TweakTests.swift */,
@@ -366,6 +372,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F43583423E7332D00FD60A7 /* test_configuration_override.json in Resources */,
 				619938E21DA8061900765852 /* test_configuration_invalid.json in Resources */,
 				619938DE1DA7F9FA00765852 /* test_configuration_no_displayable_ungrouped.json in Resources */,
 				61A561411DA7B65200839F7F /* test_configuration.json in Resources */,
@@ -480,6 +487,7 @@
 				618A46CC1DAD481400B8F5CA /* TweakExtensionsTests.swift in Sources */,
 				4F6422A721A4205B002B69F0 /* Symbols.swift in Sources */,
 				619938DC1DA7F6E600765852 /* TweakViewControllerTests.swift in Sources */,
+				4F43583223E732DD00FD60A7 /* TweakManager+PresentationTests.swift in Sources */,
 				61BE051E1DAE878600288EC7 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -43,7 +43,7 @@ PODS:
   - "GoogleUtilities/NSData+zlib (6.3.1)"
   - GoogleUtilities/UserDefaults (6.3.1):
     - GoogleUtilities/Logger
-  - JustTweak (5.1.4)
+  - JustTweak (5.2.0)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -107,7 +107,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
   GoogleDataTransportCCTSupport: f6ab1962e9dc05ab1fb938b795e5b310209edeec
   GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
-  JustTweak: ecf44c6c9a1680cd893f45c9a0dc372d7559f89d
+  JustTweak: dc29c5ba966b506c18e566c52095106d36c005ef
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   OptimizelySDKCore: 3f6018cc222b23de13ae9a71c2c15cd7fa397aed
   OptimizelySDKDatafileManager: 34edeb189ef170992677149460172ef44bfa7250

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -43,7 +43,7 @@ PODS:
   - "GoogleUtilities/NSData+zlib (6.3.1)"
   - GoogleUtilities/UserDefaults (6.3.1):
     - GoogleUtilities/Logger
-  - JustTweak (5.1.3)
+  - JustTweak (5.1.4)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -107,7 +107,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
   GoogleDataTransportCCTSupport: f6ab1962e9dc05ab1fb938b795e5b310209edeec
   GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
-  JustTweak: 22268d223f16a6c89fb64d62d2a0d32aa262cd4d
+  JustTweak: ecf44c6c9a1680cd893f45c9a0dc372d7559f89d
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   OptimizelySDKCore: 3f6018cc222b23de13ae9a71c2c15cd7fa397aed
   OptimizelySDKDatafileManager: 34edeb189ef170992677149460172ef44bfa7250

--- a/Example/Tests/Core/PropertyWrappersTests.swift
+++ b/Example/Tests/Core/PropertyWrappersTests.swift
@@ -47,31 +47,31 @@ class Accessor {
                            feature: "optional_stringValue_feature",
                            variable: "optional_stringValue_variable",
                            tweakManager: tweakManager)
-    var optionalStringValue: String
+    var optionalStringValue: String?
     
     @OptionalTweakProperty(fallbackValue: nil,
                            feature: "optional_boolValue_feature",
                            variable: "optional_boolValue_variable",
                            tweakManager: tweakManager)
-    var optionalBoolValue: Bool
+    var optionalBoolValue: Bool?
     
     @OptionalTweakProperty(fallbackValue: nil,
                            feature: "optional_intValue_feature",
                            variable: "optional_intValue_variable",
                            tweakManager: tweakManager)
-    var optionalIntValue: Int
+    var optionalIntValue: Int?
     
     @OptionalTweakProperty(fallbackValue: nil,
                            feature: "optional_doubleValue_feature",
                            variable: "optional_doubleValue_variable",
                            tweakManager: tweakManager)
-    var optionalDoubleValue: Double
+    var optionalDoubleValue: Double?
     
     @OptionalTweakProperty(fallbackValue: nil,
                            feature: "optional_floatValue_feature",
                            variable: "optional_floatValue_variable",
                            tweakManager: tweakManager)
-    var optionalFloatValue: Float
+    var optionalFloatValue: Float?
 }
 
 class FeatureFlagPropertyWrapperTests: XCTestCase {

--- a/Example/Tests/Core/TweakManager+PresentationTests.swift
+++ b/Example/Tests/Core/TweakManager+PresentationTests.swift
@@ -1,0 +1,118 @@
+//
+//  TweakManager+PresentationTests.swift
+//  JustTweak_Tests
+//
+//  Created by Alberto De Bortoli on 02/02/2020.
+//  Copyright © 2020 Just Eat. All rights reserved.
+//
+
+import XCTest
+@testable import JustTweak
+
+class TweakManager_PresentationTests: XCTestCase {
+    
+    var tweakManager: TweakManager!
+    let localConfigurationLowPriority: LocalConfiguration = {
+        let bundle = Bundle(for: TweakManagerTests.self)
+        let jsonConfigurationURL = bundle.url(forResource: "test_configuration", withExtension: "json")!
+        return LocalConfiguration(jsonURL: jsonConfigurationURL)
+    }()
+    let localConfigurationHighPriority: LocalConfiguration = {
+        let bundle = Bundle(for: TweakManagerTests.self)
+        let jsonConfigurationURL = bundle.url(forResource: "test_configuration_override", withExtension: "json")!
+        return LocalConfiguration(jsonURL: jsonConfigurationURL)
+    }()
+    
+    func test_GivenOneLocalConfiguration_WhenFetchedDisplayableTweaks_ThenAllTweaksSortedByTitleAreReturned() {
+        let configurations: [Configuration] = [localConfigurationLowPriority]
+        tweakManager = TweakManager(configurations: configurations)
+        let displayableTweaks = tweakManager.displayableTweaks
+        let targetTweaks = [
+            Tweak(feature: "ui_customization",
+                  variable: "display_green_view",
+                  value: true,
+                  title: "Display Green View",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "display_red_view",
+                  value: true,
+                  title: "Display Red View",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "display_yellow_view",
+                  value: false,
+                  title: "Display Yellow View",
+                  group: "UI Customization"),
+            Tweak(feature: "general",
+                  variable: "greet_on_app_did_become_active",
+                  value: false,
+                  title: "Greet on app launch",
+                  group: "General"),
+            Tweak(feature: "ui_customization",
+                  variable: "label_text",
+                  value: "Test value",
+                  title: "Label Text",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "red_view_alpha_component",
+                  value: 1.0,
+                  title: "Red View Alpha Component",
+                  group: "UI Customization"),
+            Tweak(feature: "general",
+                  variable: "tap_to_change_color_enabled",
+                  value: true,
+                  title: "Tap to change views color",
+                  group: "General")
+        ]
+        XCTAssertEqual(displayableTweaks, targetTweaks)
+    }
+    
+    func test_GivenTwoLocalConfigurations_WhenFetchedDisplayableTweaks_ThenTweaksFromBothConfigurationsSortedByTitleAreReturned() {
+        let configurations: [Configuration] = [localConfigurationHighPriority, localConfigurationLowPriority]
+        tweakManager = TweakManager(configurations: configurations)
+        let displayableTweaks = tweakManager.displayableTweaks
+        let targetTweaks = [
+            Tweak(feature: "ui_customization",
+                  variable: "display_blue_view",
+                  value: true,
+                  title: "Display Blue View",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "display_green_view",
+                  value: true,
+                  title: "Display Green View",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "display_red_view",
+                  value: true,
+                  title: "Display Red View",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "display_yellow_view",
+                  value: true,
+                  title: "Display Yellow View",
+                  group: "UI Customization"),
+            Tweak(feature: "general",
+                  variable: "greet_on_app_did_become_active",
+                  value: false,
+                  title: "Greet on app launch",
+                  group: "General"),
+            Tweak(feature: "ui_customization",
+                  variable: "label_text",
+                  value: "Overridden value",
+                  title: "Label Text",
+                  group: "UI Customization"),
+            Tweak(feature: "ui_customization",
+                  variable: "red_view_alpha_component",
+                  value: 1.0,
+                  title: "Red View Alpha Component",
+                  group: "UI Customization"),
+            Tweak(feature: "general",
+                  variable: "tap_to_change_color_enabled",
+                  value: false,
+                  title: "Tap to change views color",
+                  group: "General")
+        ]
+        XCTAssertEqual(displayableTweaks, targetTweaks)
+    }
+}

--- a/Example/Tests/test_configuration_override.json
+++ b/Example/Tests/test_configuration_override.json
@@ -1,0 +1,26 @@
+{
+  "ui_customization": {
+    "display_blue_view": {
+      "Title": "Display Blue View",
+      "Group": "UI Customization",
+      "Value": true
+    },
+    "display_yellow_view": {
+      "Title": "Display Yellow View",
+      "Group": "UI Customization",
+      "Value": true
+    },
+    "label_text": {
+      "Title": "Label Text",
+      "Group": "UI Customization",
+      "Value": "Overridden value"
+    }
+  },
+  "general": {
+    "tap_to_change_color_enabled": {
+      "Title": "Tap to change views color",
+      "Group": "General",
+      "Value": false
+    }
+  }
+}

--- a/JustTweak.podspec
+++ b/JustTweak.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name                    = 'JustTweak'
-  s.version                 = '5.1.4'
+  s.version                 = '5.2.0'
   s.summary                 = 'A framework for feature flagging, locally and remotely configure and A/B test iOS apps.'
   s.description             = <<-DESC
 JustTweak is a framework for feature flagging, locally and remotely configure and A/B test iOS apps.

--- a/JustTweak/Classes/UI/TweakManager+Presentation.swift
+++ b/JustTweak/Classes/UI/TweakManager+Presentation.swift
@@ -8,28 +8,28 @@ import Foundation
 extension TweakManager {
     
     var displayableTweaks: [Tweak] {
-        guard let localConfiguration = self.localConfiguration else {
-            return []
-        }
-        var tweaks = [Tweak]()
-        for (feature, variables) in localConfiguration.features {
-            for variable in variables {
-                if let tweak = tweakWith(feature: feature, variable: variable) {
-                    let jsonTweak = localConfiguration.tweakWith(feature: feature, variable: variable)
-                    let aggregatedTweak = Tweak(feature: feature,
-                                                variable: variable,
-                                                value: tweak.value,
-                                                title: jsonTweak?.title,
-                                                description: jsonTweak?.desc,
-                                                group: jsonTweak?.group)
-                    tweaks.append(aggregatedTweak)
+        var tweaks = [String : Tweak]()
+        for localConfiguration in self.localConfigurations.reversed() {
+            for (feature, variables) in localConfiguration.features {
+                for variable in variables {
+                    if let tweak = tweakWith(feature: feature, variable: variable),
+                        let jsonTweak = localConfiguration.tweakWith(feature: feature, variable: variable) {
+                        let aggregatedTweak = Tweak(feature: feature,
+                                                    variable: variable,
+                                                    value: tweak.value,
+                                                    title: jsonTweak.title,
+                                                    description: jsonTweak.desc,
+                                                    group: jsonTweak.group)
+                        let key = "\(feature)-\(variable)"
+                        tweaks[key] = aggregatedTweak
+                    }
                 }
             }
         }
-        return tweaks.sorted(by: { $0.displayTitle < $1.displayTitle })
+        return tweaks.values.sorted(by: { $0.displayTitle < $1.displayTitle })
     }
     
-    private var localConfiguration: LocalConfiguration? {
-        return configurations.first { $0 is LocalConfiguration } as? LocalConfiguration
+    private var localConfigurations: [LocalConfiguration] {
+        return configurations.filter { $0 is LocalConfiguration } as! [LocalConfiguration]
     }
 }


### PR DESCRIPTION
This PR adds support for using multiple `LocalConfiguration`s in a way that allows showing correctly the tweaks in the `TweakViewController`, merging them from all the `LocalConfiguration`s respecting the implied configuration priority.

It also fixes unit tests that - for some reason - appear to not compile in the master branch.