### PR TITLE
Fix wrong cast in TextTweakTableViewCell.swift

### DIFF
--- a/JustTweak/Classes/Extensions/TweakExtensions.swift
+++ b/JustTweak/Classes/Extensions/TweakExtensions.swift
@@ -5,21 +5,6 @@
 
 import Foundation
 
-extension String {
-    
-    var isInt: Bool {
-        Int(self) != nil
-    }
-    
-    var isDouble: Bool {
-        Double(self) != nil
-    }
-    
-    var isFloat: Bool {
-        Float(self) != nil
-    }
-}
-
 public extension String {
     
     var tweakValue: TweakValue {

--- a/JustTweak/Classes/Extensions/TweakExtensions.swift
+++ b/JustTweak/Classes/Extensions/TweakExtensions.swift
@@ -5,6 +5,21 @@
 
 import Foundation
 
+extension String {
+    
+    var isInt: Bool {
+        Int(self) != nil
+    }
+    
+    var isDouble: Bool {
+        Double(self) != nil
+    }
+    
+    var isFloat: Bool {
+        Float(self) != nil
+    }
+}
+
 public extension String {
     
     var tweakValue: TweakValue {

--- a/JustTweak/Classes/UI/Cells/TextTweakTableViewCell.swift
+++ b/JustTweak/Classes/UI/Cells/TextTweakTableViewCell.swift
@@ -68,14 +68,14 @@ class TextTweakTableViewCell: UITableViewCell, TweakViewControllerCell, UITextFi
     
     @objc func textDidChange() {
         guard let text = textField.text else { return }
-        if text.isInt {
-            value = Int(text)!
+        if let int = Int(text) {
+            value = int
         }
-        else if text.isDouble {
-            value = Double(text)!
+        else if let double = Double(text) {
+            value = double
         }
-        else if text.isFloat {
-            value = Float(text)!
+        else if let float = Float(text) {
+            value = float
         }
         else {
             value = text

--- a/JustTweak/Classes/UI/Cells/TextTweakTableViewCell.swift
+++ b/JustTweak/Classes/UI/Cells/TextTweakTableViewCell.swift
@@ -67,7 +67,19 @@ class TextTweakTableViewCell: UITableViewCell, TweakViewControllerCell, UITextFi
     }()
     
     @objc func textDidChange() {
-        value = textField.text!
+        guard let text = textField.text else { return }
+        if text.isInt {
+            value = Int(text)!
+        }
+        else if text.isDouble {
+            value = Double(text)!
+        }
+        else if text.isFloat {
+            value = Float(text)!
+        }
+        else {
+            value = text
+        }
     }
     
     @objc func textEditingDidEnd() {


### PR DESCRIPTION
The recent changes (introduced with #51) highlighted an underlying issue in `TextTweakTableViewCell.textDidChange()`.

The `TweakViewController` assigns a `String` to `Int`/`Double`/`Float` `TweakValue`s ultimately causing a crash when the feature flag is accessed via the generated property wrapper in the getter of `wrappedValuewrappedValue`.

This was the case even before v6.0.0 as the property wrappers were introduced previously.

Checking for `Int` and `Double` should be enough but I've added `Float` as well to be consistent with the types conforming to `TweakValue`. `Bool` shows in the UI as a toggle, so that won't be a problem.