### PR TITLE
Tweak getter function made throwable

### DIFF
--- a/Errors/TweakError.swift
+++ b/Errors/TweakError.swift
@@ -1,0 +1,14 @@
+//
+//  TweakError.swift
+//  JustTweak
+//
+//  Created by Sania Zafar on 06/01/2022.
+//
+
+import Foundation
+
+public enum TweakError: String, Error {
+    case notFound = "Feature or variable is not found"
+    case notSupported = "Variable type is not supported"
+    case decryptionClosureNotProvided = "Value is encrypted but there's no decryption closure provided"
+}

--- a/Errors/TweakError.swift
+++ b/Errors/TweakError.swift
@@ -1,8 +1,6 @@
 //
 //  TweakError.swift
-//  JustTweak
-//
-//  Created by Sania Zafar on 06/01/2022.
+//  Copyright (c) 2022 Just Eat Holding Ltd. All rights reserved.
 //
 
 import Foundation

--- a/Example/JustTweak/Accessors/GeneratedTweakAccessor.swift
+++ b/Example/JustTweak/Accessors/GeneratedTweakAccessor.swift
@@ -15,47 +15,47 @@ class GeneratedTweakAccessor {
     }
 
     var canShowGreenView: Bool {
-        get { tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayGreenView)?.boolValue ?? false }
+        get { (try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayGreenView))?.boolValue ?? false }
         set { tweakManager.set(newValue, feature: Features.uiCustomization, variable: Variables.displayGreenView) }
     }
 
     var canShowRedView: Bool {
-        get { tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView)?.boolValue ?? false }
+        get { (try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView))?.boolValue ?? false }
         set { tweakManager.set(newValue, feature: Features.uiCustomization, variable: Variables.displayRedView) }
     }
 
     var canShowYellowView: Bool {
-        get { tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView)?.boolValue ?? false }
+        get { (try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView))?.boolValue ?? false }
         set { tweakManager.set(newValue, feature: Features.uiCustomization, variable: Variables.displayYellowView) }
     }
 
     var definitiveAnswerEncrypted: String {
-        get { tweakManager.tweakWith(feature: Features.general, variable: Variables.encryptedAnswerToTheUniverse)?.stringValue ?? "" }
+        get { (try? tweakManager.tweakWith(feature: Features.general, variable: Variables.encryptedAnswerToTheUniverse))?.stringValue ?? "" }
         set { tweakManager.set(newValue, feature: Features.general, variable: Variables.encryptedAnswerToTheUniverse) }
     }
 
     var isTapGestureToChangeColorEnabled: Bool {
-        get { tweakManager.tweakWith(feature: Features.general, variable: Variables.tapToChangeColorEnabled)?.boolValue ?? false }
+        get { (try? tweakManager.tweakWith(feature: Features.general, variable: Variables.tapToChangeColorEnabled))?.boolValue ?? false }
         set { tweakManager.set(newValue, feature: Features.general, variable: Variables.tapToChangeColorEnabled) }
     }
 
     var labelText: String {
-        get { tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.labelText)?.stringValue ?? "" }
+        get { (try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.labelText))?.stringValue ?? "" }
         set { tweakManager.set(newValue, feature: Features.uiCustomization, variable: Variables.labelText) }
     }
 
     var meaningOfLife: Int {
-        get { tweakManager.tweakWith(feature: Features.general, variable: Variables.answerToTheUniverse)?.intValue ?? 0 }
+        get { (try? tweakManager.tweakWith(feature: Features.general, variable: Variables.answerToTheUniverse))?.intValue ?? 0 }
         set { tweakManager.set(newValue, feature: Features.general, variable: Variables.answerToTheUniverse) }
     }
 
     var redViewAlpha: Double {
-        get { tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.redViewAlphaComponent)?.doubleValue ?? 0.0 }
+        get { (try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.redViewAlphaComponent))?.doubleValue ?? 0.0 }
         set { tweakManager.set(newValue, feature: Features.uiCustomization, variable: Variables.redViewAlphaComponent) }
     }
 
     var shouldShowAlert: Bool {
-        get { tweakManager.tweakWith(feature: Features.general, variable: Variables.greetOnAppDidBecomeActive)?.boolValue ?? false }
+        get { (try? tweakManager.tweakWith(feature: Features.general, variable: Variables.greetOnAppDidBecomeActive))?.boolValue ?? false }
         set { tweakManager.set(newValue, feature: Features.general, variable: Variables.greetOnAppDidBecomeActive) }
     }
 }

--- a/Example/JustTweak/Accessors/TweakAccessor.swift
+++ b/Example/JustTweak/Accessors/TweakAccessor.swift
@@ -88,17 +88,17 @@ class TweakAccessor {
     
     var canShowYellowView: Bool {
         return (try? tweakManager.tweakWith(feature: Features.uiCustomization,
-                                      variable: Variables.displayYellowView))?.boolValue ?? false
+                                            variable: Variables.displayYellowView))?.boolValue ?? false
     }
 
     var redViewAlpha: Float {
         return (try? tweakManager.tweakWith(feature: Features.uiCustomization,
-                                      variable: Variables.redViewAlpha))?.floatValue ?? 0.0
+                                            variable: Variables.redViewAlpha))?.floatValue ?? 0.0
     }
 
     var isTapGestureToChangeColorEnabled: Bool {
         return (try? tweakManager.tweakWith(feature: Features.general,
-                                      variable: Variables.tapToChangeViewColor))?.boolValue ?? false
+                                            variable: Variables.tapToChangeViewColor))?.boolValue ?? false
     }
 }
 

--- a/Example/JustTweak/Accessors/TweakAccessor.swift
+++ b/Example/JustTweak/Accessors/TweakAccessor.swift
@@ -87,18 +87,18 @@ class TweakAccessor {
     // MARK: - Via TweakManager
     
     var canShowYellowView: Bool {
-        return tweakManager.tweakWith(feature: Features.uiCustomization,
-                                      variable: Variables.displayYellowView)?.boolValue ?? false
+        return (try? tweakManager.tweakWith(feature: Features.uiCustomization,
+                                      variable: Variables.displayYellowView))?.boolValue ?? false
     }
-    
+
     var redViewAlpha: Float {
-        return tweakManager.tweakWith(feature: Features.uiCustomization,
-                                      variable: Variables.redViewAlpha)?.floatValue ?? 0.0
+        return (try? tweakManager.tweakWith(feature: Features.uiCustomization,
+                                      variable: Variables.redViewAlpha))?.floatValue ?? 0.0
     }
-    
+
     var isTapGestureToChangeColorEnabled: Bool {
-        return tweakManager.tweakWith(feature: Features.general,
-                                      variable: Variables.tapToChangeViewColor)?.boolValue ?? false
+        return (try? tweakManager.tweakWith(feature: Features.general,
+                                      variable: Variables.tapToChangeViewColor))?.boolValue ?? false
     }
 }
 

--- a/Example/JustTweak/TweakProviders/FirebaseTweakProvider.swift
+++ b/Example/JustTweak/TweakProviders/FirebaseTweakProvider.swift
@@ -55,8 +55,8 @@ public class FirebaseTweakProvider: TweakProvider {
         return configValue.boolValue
     }
     
-    public func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard configured else { return nil }
+    public func tweakWith(feature: String, variable: String) throws -> Tweak {
+        guard configured else { throw TweakError.notFound }
         let configValue = remoteConfiguration.configValue(forKey: variable)
         guard configValue.source != .static else { return nil }
         guard let stringValue = configValue.stringValue else { return nil }

--- a/Example/JustTweak/TweakProviders/OptimizelyTweakProvider.swift
+++ b/Example/JustTweak/TweakProviders/OptimizelyTweakProvider.swift
@@ -47,9 +47,12 @@ public class OptimizelyTweakProvider: TweakProvider {
         return optimizelyClient?.isFeatureEnabled(feature, userId: userId, attributes: attributes) ?? false
     }
     
-    public func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard let optimizelyClient = optimizelyClient else { return nil }
-        guard optimizelyClient.isFeatureEnabled(feature, userId: userId, attributes: attributes) == true else { return nil }
+    public func tweakWith(feature: String, variable: String) throws -> Tweak {
+        guard let optimizelyClient = optimizelyClient,
+              optimizelyClient.isFeatureEnabled(feature, userId: userId, attributes: attributes) == true
+        else {
+            throw TweakError.notFound
+        }
         
         let tweakValue: TweakValue? = {
             if let boolValue = optimizelyClient.getFeatureVariableBoolean(feature, variableKey: variable, userId: userId, attributes: attributes)?.boolValue {
@@ -66,11 +69,10 @@ public class OptimizelyTweakProvider: TweakProvider {
             }
             return nil
         }()
-        
-        if let tweakValue = tweakValue {
-            return Tweak(feature: feature, variable: variable, value: tweakValue, title: nil, group: nil)
+
+        guard let tweakValue = tweakValue else {
+            throw TweakError.notFound
         }
-        
-        return nil
+        return Tweak(feature: feature, variable: variable, value: tweakValue, title: nil, group: nil)
     }
 }

--- a/Example/Tests/Core/LocalTweakProviderTests.swift
+++ b/Example/Tests/Core/LocalTweakProviderTests.swift
@@ -32,7 +32,7 @@ class LocalTweakProviderTests: XCTestCase {
                                  value: true,
                                  title: "Display Red View",
                                  group: "UI Customization")
-        XCTAssertEqual(redViewTweak, tweakProvider.tweakWith(feature: Features.uiCustomization,
+        XCTAssertEqual(redViewTweak, try tweakProvider.tweakWith(feature: Features.uiCustomization,
                                                              variable: Variables.displayRedView))
     }
     
@@ -42,7 +42,7 @@ class LocalTweakProviderTests: XCTestCase {
                                       value: 1.0,
                                       title: "Red View Alpha Component",
                                       group: "UI Customization")
-        XCTAssertEqual(redViewAlphaTweak, tweakProvider.tweakWith(feature: Features.uiCustomization,
+        XCTAssertEqual(redViewAlphaTweak, try tweakProvider.tweakWith(feature: Features.uiCustomization,
                                                                   variable: Variables.redViewAlpha))
     }
     
@@ -51,7 +51,7 @@ class LocalTweakProviderTests: XCTestCase {
                                      variable: Variables.labelText,
                                      value: "Test value",
                                      title: "Label Text", group: "UI Customization")
-        XCTAssertEqual(buttonLabelTweak, tweakProvider.tweakWith(feature: Features.uiCustomization,
+        XCTAssertEqual(buttonLabelTweak, try tweakProvider.tweakWith(feature: Features.uiCustomization,
                                                                  variable: Variables.labelText))
     }
     

--- a/Example/Tests/Core/LocalTweakProviderTests.swift
+++ b/Example/Tests/Core/LocalTweakProviderTests.swift
@@ -33,7 +33,7 @@ class LocalTweakProviderTests: XCTestCase {
                                  title: "Display Red View",
                                  group: "UI Customization")
         XCTAssertEqual(redViewTweak, try tweakProvider.tweakWith(feature: Features.uiCustomization,
-                                                             variable: Variables.displayRedView))
+                                                                 variable: Variables.displayRedView))
     }
     
     func testParsesFloatTweak() {
@@ -43,7 +43,7 @@ class LocalTweakProviderTests: XCTestCase {
                                       title: "Red View Alpha Component",
                                       group: "UI Customization")
         XCTAssertEqual(redViewAlphaTweak, try tweakProvider.tweakWith(feature: Features.uiCustomization,
-                                                                  variable: Variables.redViewAlpha))
+                                                                      variable: Variables.redViewAlpha))
     }
     
     func testParsesStringTweak() {
@@ -52,7 +52,7 @@ class LocalTweakProviderTests: XCTestCase {
                                      value: "Test value",
                                      title: "Label Text", group: "UI Customization")
         XCTAssertEqual(buttonLabelTweak, try tweakProvider.tweakWith(feature: Features.uiCustomization,
-                                                                 variable: Variables.labelText))
+                                                                     variable: Variables.labelText))
     }
     
     func testDecryptionClosure() {

--- a/Example/Tests/Core/TweakManagerCacheTests.swift
+++ b/Example/Tests/Core/TweakManagerCacheTests.swift
@@ -5,6 +5,7 @@
 
 import XCTest
 @testable import JustTweak
+@testable import JustTweak_Example
 
 fileprivate struct Constants {
     static let featureActiveValue = true
@@ -68,15 +69,15 @@ class TweakManagerCacheTests: XCTestCase {
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, 0)
         let value = true
         tweakManager.set(value, feature: Constants.feature, variable: Constants.variable)
-        XCTAssertEqual(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)!.value as! Bool, value)
+        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, 1)
-        XCTAssertEqual(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)!.value as! Bool, value)
+        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, useCache ? 1 : 2)
         tweakManager.set(value, feature: Constants.feature, variable: Constants.variable)
-        XCTAssertEqual(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)!.value as! Bool, value)
+        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, useCache ? 2 : 3)
         tweakManager.resetCache()
-        XCTAssertEqual(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)!.value as! Bool, value)
+        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, useCache ? 3 : 4)
     }
 }
@@ -97,9 +98,12 @@ fileprivate class MockTweakProvider: MutableTweakProvider {
         return featureBackingStore[feature] ?? false
     }
     
-    func tweakWith(feature: String, variable: String) -> Tweak? {
+    func tweakWith(feature: String, variable: String) throws -> Tweak {
         tweakWithFeatureVariableCallsCounter += 1
-        return tweakBackingStore[feature]?[variable]
+        guard let tweak = tweakBackingStore[feature]?[variable] else {
+            throw TweakError.notFound
+        }
+        return tweak
     }
     
     func set(_ value: TweakValue, feature: String, variable: String) {

--- a/Example/Tests/Core/TweakManagerCacheTests.swift
+++ b/Example/Tests/Core/TweakManagerCacheTests.swift
@@ -56,28 +56,28 @@ class TweakManagerCacheTests: XCTestCase {
     
     // MARK: - tweakWith(feature:variable:)
     
-    func testTweakFetch_CacheDisabled() {
-        tweakFetch(useCache: false)
+    func testTweakFetch_CacheDisabled() throws {
+        try tweakFetch(useCache: false)
     }
     
-    func testTweakFetch_CacheEnabled() {
-        tweakFetch(useCache: true)
+    func testTweakFetch_CacheEnabled() throws {
+        try tweakFetch(useCache: true)
     }
     
-    private func tweakFetch(useCache: Bool) {
+    private func tweakFetch(useCache: Bool) throws {
         tweakManager.useCache = useCache
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, 0)
         let value = true
         tweakManager.set(value, feature: Constants.feature, variable: Constants.variable)
-        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
+        XCTAssertEqual(try XCTUnwrap(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, 1)
-        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
+        XCTAssertEqual(try XCTUnwrap(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, useCache ? 1 : 2)
         tweakManager.set(value, feature: Constants.feature, variable: Constants.variable)
-        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
+        XCTAssertEqual(try XCTUnwrap(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, useCache ? 2 : 3)
         tweakManager.resetCache()
-        XCTAssertEqual(try! tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable).value as! Bool, value)
+        XCTAssertEqual(try XCTUnwrap(tweakManager.tweakWith(feature: Constants.feature, variable: Constants.variable)).value as! Bool, value)
         XCTAssertEqual(mockTweakProvider.tweakWithFeatureVariableCallsCounter, useCache ? 3 : 4)
     }
 }

--- a/Example/Tests/Core/TweakManagerTests.swift
+++ b/Example/Tests/Core/TweakManagerTests.swift
@@ -37,33 +37,33 @@ class TweakManagerTests: XCTestCase {
     }
     
     func testReturnsNil_ForUndefinedTweak() {
-        XCTAssertNil(tweakManager.tweakWith(feature: Features.uiCustomization, variable: "some_undefined_tweak"))
+        XCTAssertNil(try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: "some_undefined_tweak"))
     }
     
     func testReturnsRemoteConfigValue_ForDisplayRedViewTweak() {
-        XCTAssertTrue(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView)!.boolValue)
+        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView).boolValue)
     }
     
     func testReturnsRemoteConfigValue_ForDisplayYellowViewTweak() {
-        XCTAssertFalse(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView)!.boolValue)
+        XCTAssertFalse(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView).boolValue)
     }
     
     func testReturnsRemoteConfigValue_ForDisplayGreenViewTweak() {
-        XCTAssertFalse(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayGreenView)!.boolValue)
+        XCTAssertFalse(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayGreenView).boolValue)
     }
     
     func testReturnsRemoteConfigValue_ForGreetOnAppDidBecomeActiveTweak() {
-        XCTAssertTrue(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive)!.boolValue)
+        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive).boolValue)
     }
     
     func testReturnsJSONConfigValue_ForTapToChangeViewColorTweak_AsYetUnkown() {
-        XCTAssertTrue(tweakManager.tweakWith(feature: Features.general, variable: Variables.tapToChangeViewColor)!.boolValue)
+        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.general, variable: Variables.tapToChangeViewColor).boolValue)
     }
     
     func testReturnsUserSetValue_ForGreetOnAppDidBecomeActiveTweak_AfterUpdatingUserDefaultsTweakProvider() {
         let mutableTweakProvider = tweakManager.mutableTweakProvider!
         mutableTweakProvider.set(false, feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive)
-        XCTAssertFalse(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive)!.boolValue)
+        XCTAssertFalse(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive).boolValue)
     }
     
     func testCallsClosureForRegisteredObserverWhenAnyConfigurationChanges() {
@@ -100,7 +100,7 @@ class TweakManagerTests: XCTestCase {
         
         let feature = "general"
         let variable = "encrypted_answer_to_the_universe"
-        let tweak = tweakManager.tweakWith(feature: feature, variable: variable)
+        let tweak = try? tweakManager.tweakWith(feature: feature, variable: variable)
         
         XCTAssertEqual("Definitely not 42", tweak?.stringValue)
     }
@@ -132,8 +132,8 @@ fileprivate class MockTweakProvider: TweakProvider {
         return false
     }
     
-    func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard let value = knownValues[variable] else { return nil }
+    func tweakWith(feature: String, variable: String) throws -> Tweak {
+        guard let value = knownValues[variable] else { throw TweakError.notFound }
         return Tweak(feature: feature, variable: variable, value: value["Value"]!, title: nil, group: nil)
     }
 }

--- a/Example/Tests/Core/TweakManagerTests.swift
+++ b/Example/Tests/Core/TweakManagerTests.swift
@@ -40,30 +40,30 @@ class TweakManagerTests: XCTestCase {
         XCTAssertNil(try? tweakManager.tweakWith(feature: Features.uiCustomization, variable: "some_undefined_tweak"))
     }
     
-    func testReturnsRemoteConfigValue_ForDisplayRedViewTweak() {
-        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView).boolValue)
+    func testReturnsRemoteConfigValue_ForDisplayRedViewTweak() throws {
+        XCTAssertTrue(try XCTUnwrap(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView)).boolValue)
     }
     
-    func testReturnsRemoteConfigValue_ForDisplayYellowViewTweak() {
-        XCTAssertFalse(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView).boolValue)
+    func testReturnsRemoteConfigValue_ForDisplayYellowViewTweak() throws {
+        XCTAssertFalse(try XCTUnwrap(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView)).boolValue)
     }
     
-    func testReturnsRemoteConfigValue_ForDisplayGreenViewTweak() {
-        XCTAssertFalse(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayGreenView).boolValue)
+    func testReturnsRemoteConfigValue_ForDisplayGreenViewTweak() throws {
+        XCTAssertFalse(try XCTUnwrap(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayGreenView)).boolValue)
     }
     
-    func testReturnsRemoteConfigValue_ForGreetOnAppDidBecomeActiveTweak() {
-        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive).boolValue)
+    func testReturnsRemoteConfigValue_ForGreetOnAppDidBecomeActiveTweak() throws {
+        XCTAssertTrue(try XCTUnwrap(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive)).boolValue)
     }
     
-    func testReturnsJSONConfigValue_ForTapToChangeViewColorTweak_AsYetUnkown() {
-        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.general, variable: Variables.tapToChangeViewColor).boolValue)
+    func testReturnsJSONConfigValue_ForTapToChangeViewColorTweak_AsYetUnkown() throws {
+        XCTAssertTrue(try XCTUnwrap(tweakManager.tweakWith(feature: Features.general, variable: Variables.tapToChangeViewColor)).boolValue)
     }
     
-    func testReturnsUserSetValue_ForGreetOnAppDidBecomeActiveTweak_AfterUpdatingUserDefaultsTweakProvider() {
+    func testReturnsUserSetValue_ForGreetOnAppDidBecomeActiveTweak_AfterUpdatingUserDefaultsTweakProvider() throws {
         let mutableTweakProvider = tweakManager.mutableTweakProvider!
         mutableTweakProvider.set(false, feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive)
-        XCTAssertFalse(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive).boolValue)
+        XCTAssertFalse(try XCTUnwrap(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.greetOnAppDidBecomeActive)).boolValue)
     }
     
     func testCallsClosureForRegisteredObserverWhenAnyConfigurationChanges() {

--- a/Example/Tests/Core/UserDefaultsTweakProviderTests.swift
+++ b/Example/Tests/Core/UserDefaultsTweakProviderTests.swift
@@ -24,17 +24,17 @@ class UserDefaultsTweakProviderTests: XCTestCase {
         super.tearDown()
     }
     
-    func testReturnsCorrectTweaksIdentifiersWhenInitializedAndTweaksHaveBeenSet() {
+    func testReturnsCorrectTweaksIdentifiersWhenInitializedAndTweaksHaveBeenSet() throws {
         let anotherConfiguration = UserDefaultsTweakProvider(userDefaults: userDefaults)
         anotherConfiguration.set("hello", feature: "feature_1", variable: "variable_4")
         anotherConfiguration.set(true, feature: "feature_1", variable: "variable_3")
         anotherConfiguration.set(12.34, feature: "feature_1", variable: "variable_2")
         anotherConfiguration.set(42, feature: "feature_1", variable: "variable_1")
         
-        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_1").value == 42)
-        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_2").value == 12.34)
-        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_3").value == true)
-        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_4").value == "hello")
+        XCTAssertTrue(try XCTUnwrap(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_1")).value == 42)
+        XCTAssertTrue(try XCTUnwrap(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_2")).value == 12.34)
+        XCTAssertTrue(try XCTUnwrap(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_3")).value == true)
+        XCTAssertTrue(try XCTUnwrap(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_4")).value == "hello")
     }
     
     func testReturnsNilForTweaksThatHaveNoUserDefaultValue() {
@@ -42,33 +42,33 @@ class UserDefaultsTweakProviderTests: XCTestCase {
         XCTAssertNil(tweak)
     }
     
-    func testUpdatesValueForTweak_withBool() {
+    func testUpdatesValueForTweak_withBool() throws {
         userDefaultsTweakProvider.set(true, feature: "feature_1", variable: "variable_1")
-        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
-        XCTAssertTrue(tweak.value == true)
+        let tweak = try XCTUnwrap(userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1"))
+        XCTAssertTrue(tweak.value.boolValue)
     }
     
-    func testUpdatesValueForTweak_withInteger() {
+    func testUpdatesValueForTweak_withInteger() throws {
         userDefaultsTweakProvider.set(42, feature: "feature_1", variable: "variable_1")
-        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        let tweak = try XCTUnwrap(userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1"))
         XCTAssertTrue(tweak.value == 42)
     }
     
-    func testUpdatesValueForTweak_withFloat() {
+    func testUpdatesValueForTweak_withFloat() throws {
         userDefaultsTweakProvider.set(Float(12.34), feature: "feature_1", variable: "variable_1")
-        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        let tweak = try XCTUnwrap(userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1"))
         XCTAssertTrue(tweak.value == Float(12.34))
     }
     
-    func testUpdatesValueForTweak_withDouble() {
+    func testUpdatesValueForTweak_withDouble() throws {
         userDefaultsTweakProvider.set(Double(23.45), feature: "feature_1", variable: "variable_1")
-        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        let tweak = try XCTUnwrap(userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1"))
         XCTAssertTrue(tweak.value == Double(23.45))
     }
     
-    func testUpdatesValueForTweak_withString() {
+    func testUpdatesValueForTweak_withString() throws {
         userDefaultsTweakProvider.set("Hello", feature: "feature_1", variable: "variable_1")
-        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        let tweak = try XCTUnwrap(userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1"))
         XCTAssertTrue(tweak.value == "Hello")
     }
     

--- a/Example/Tests/Core/UserDefaultsTweakProviderTests.swift
+++ b/Example/Tests/Core/UserDefaultsTweakProviderTests.swift
@@ -31,45 +31,45 @@ class UserDefaultsTweakProviderTests: XCTestCase {
         anotherConfiguration.set(12.34, feature: "feature_1", variable: "variable_2")
         anotherConfiguration.set(42, feature: "feature_1", variable: "variable_1")
         
-        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_1")!.value == 42)
-        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_2")!.value == 12.34)
-        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_3")!.value == true)
-        XCTAssertTrue(anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_4")!.value == "hello")
+        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_1").value == 42)
+        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_2").value == 12.34)
+        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_3").value == true)
+        XCTAssertTrue(try! anotherConfiguration.tweakWith(feature: "feature_1", variable: "variable_4").value == "hello")
     }
     
     func testReturnsNilForTweaksThatHaveNoUserDefaultValue() {
-        let tweak = userDefaultsTweakProvider.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView)
+        let tweak = try? userDefaultsTweakProvider.tweakWith(feature: Features.uiCustomization, variable: Variables.displayRedView)
         XCTAssertNil(tweak)
     }
     
     func testUpdatesValueForTweak_withBool() {
         userDefaultsTweakProvider.set(true, feature: "feature_1", variable: "variable_1")
-        let tweak = userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
-        XCTAssertTrue(tweak!.value == true)
+        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        XCTAssertTrue(tweak.value == true)
     }
     
     func testUpdatesValueForTweak_withInteger() {
         userDefaultsTweakProvider.set(42, feature: "feature_1", variable: "variable_1")
-        let tweak = userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
-        XCTAssertTrue(tweak!.value == 42)
+        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        XCTAssertTrue(tweak.value == 42)
     }
     
     func testUpdatesValueForTweak_withFloat() {
         userDefaultsTweakProvider.set(Float(12.34), feature: "feature_1", variable: "variable_1")
-        let tweak = userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
-        XCTAssertTrue(tweak!.value == Float(12.34))
+        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        XCTAssertTrue(tweak.value == Float(12.34))
     }
     
     func testUpdatesValueForTweak_withDouble() {
         userDefaultsTweakProvider.set(Double(23.45), feature: "feature_1", variable: "variable_1")
-        let tweak = userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
-        XCTAssertTrue(tweak!.value == Double(23.45))
+        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        XCTAssertTrue(tweak.value == Double(23.45))
     }
     
     func testUpdatesValueForTweak_withString() {
         userDefaultsTweakProvider.set("Hello", feature: "feature_1", variable: "variable_1")
-        let tweak = userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
-        XCTAssertTrue(tweak!.value == "Hello")
+        let tweak = try! userDefaultsTweakProvider.tweakWith(feature: "feature_1", variable: "variable_1")
+        XCTAssertTrue(tweak.value == "Hello")
     }
     
     func testDecryptionClosure() {

--- a/Example/Tests/UI/TweakViewControllerTests.swift
+++ b/Example/Tests/UI/TweakViewControllerTests.swift
@@ -131,7 +131,7 @@ class TweakViewControllerTests: XCTestCase {
         let cell = viewController.tableView.cellForRow(at: indexPath) as! BooleanTweakTableViewCell
         cell.switchControl.isOn = true
         cell.switchControl.sendActions(for: .valueChanged)
-        XCTAssertTrue(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView)!.boolValue)
+        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView).boolValue)
     }
     
     // MARK: Other Actions

--- a/Example/Tests/UI/TweakViewControllerTests.swift
+++ b/Example/Tests/UI/TweakViewControllerTests.swift
@@ -123,7 +123,7 @@ class TweakViewControllerTests: XCTestCase {
     
     // MARK: Cells Actions
     
-    func testUpdatesValueOfTweak_WhenUserTooglesSwitchOnBooleanCell() {
+    func testUpdatesValueOfTweak_WhenUserTooglesSwitchOnBooleanCell() throws {
         viewController.beginAppearanceTransition(true, animated: false)
         viewController.endAppearanceTransition()
         
@@ -131,7 +131,7 @@ class TweakViewControllerTests: XCTestCase {
         let cell = viewController.tableView.cellForRow(at: indexPath) as! BooleanTweakTableViewCell
         cell.switchControl.isOn = true
         cell.switchControl.sendActions(for: .valueChanged)
-        XCTAssertTrue(try! tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView).boolValue)
+        XCTAssertTrue(try XCTUnwrap(tweakManager.tweakWith(feature: Features.uiCustomization, variable: Variables.displayYellowView)).boolValue)
     }
     
     // MARK: Other Actions

--- a/JustTweak.podspec
+++ b/JustTweak.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'JustTweak'
-  s.version                 = '9.0.1'
+  s.version                 = '10.0.0'
   s.summary                 = 'A framework for feature flagging, locally and remotely configure and A/B test iOS apps.'
   s.description             = <<-DESC
 JustTweak is a framework for feature flagging, locally and remotely configure and A/B test iOS apps.

--- a/JustTweak.podspec
+++ b/JustTweak.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'JustTweak'
-  s.version                 = '9.0.0'
+  s.version                 = '9.0.1'
   s.summary                 = 'A framework for feature flagging, locally and remotely configure and A/B test iOS apps.'
   s.description             = <<-DESC
 JustTweak is a framework for feature flagging, locally and remotely configure and A/B test iOS apps.

--- a/JustTweak/Classes/Protocols/TweakProvider.swift
+++ b/JustTweak/Classes/Protocols/TweakProvider.swift
@@ -14,7 +14,7 @@ public typealias LogClosure = (String, LogLevel) -> Void
 public protocol TweakProvider {
     var logClosure: LogClosure? { set get }
     func isFeatureEnabled(_ feature: String) -> Bool
-    func tweakWith(feature: String, variable: String) -> Tweak?
+    func tweakWith(feature: String, variable: String) throws -> Tweak
     
     var decryptionClosure: ((Tweak) -> TweakValue)? { get set }
 }

--- a/JustTweak/Classes/TweakProviders/EphemeralTweakProvider.swift
+++ b/JustTweak/Classes/TweakProviders/EphemeralTweakProvider.swift
@@ -23,8 +23,8 @@ extension NSDictionary: TweakProvider {
         self[feature] as? Bool ?? false
     }
     
-    public func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard let storedValue = self[variable] else { return nil }
+    public func tweakWith(feature: String, variable: String) throws -> Tweak {
+        guard let storedValue = self[variable] else { throw TweakError.notFound }
         var value: TweakValue? = nil
         if let theValue = storedValue as? String {
             value = theValue
@@ -32,7 +32,7 @@ extension NSDictionary: TweakProvider {
         else if let theValue = storedValue as? NSNumber {
             value = theValue.tweakValue
         }
-        guard let finalValue = value else { return nil }
+        guard let finalValue = value else { throw TweakError.notSupported }
         return Tweak(feature: feature, variable: variable, value: finalValue)
     }
 }

--- a/JustTweak/Classes/TweakProviders/LocalTweakProvider.swift
+++ b/JustTweak/Classes/TweakProviders/LocalTweakProvider.swift
@@ -60,8 +60,8 @@ extension LocalTweakProvider: TweakProvider {
         return configurationFile[feature] != nil
     }
     
-    public func tweakWith(feature: String, variable: String) -> Tweak? {
-        guard let entry = configurationFile[feature]?[variable] else { return nil }
+    public func tweakWith(feature: String, variable: String) throws -> Tweak {
+        guard let entry = configurationFile[feature]?[variable] else { throw TweakError.notFound }
         let title = entry[EncodingKeys.Title.rawValue] as? String
         let description = entry[EncodingKeys.Description.rawValue] as? String
         let group = entry[EncodingKeys.Group.rawValue] as? String
@@ -78,8 +78,7 @@ extension LocalTweakProvider: TweakProvider {
         if isEncrypted {
             guard let decryptionClosure = decryptionClosure else {
                 // The configuration is not correct, it's encrypted, but there's no way to decrypt
-                // So return nil to indicate an error. Should be changed to a throwing function in the future
-                return nil
+                throw TweakError.decryptionClosureNotProvided
             }
             
             return tweak.mutatedCopy(value: decryptionClosure(tweak))

--- a/JustTweak/Classes/TweakProviders/UserDefaultsTweakProvider.swift
+++ b/JustTweak/Classes/TweakProviders/UserDefaultsTweakProvider.swift
@@ -26,10 +26,10 @@ extension UserDefaultsTweakProvider: TweakProvider {
         return userDefaults.bool(forKey: userDefaultsKey)
     }
 
-    public func tweakWith(feature: String, variable: String) -> Tweak? {
+    public func tweakWith(feature: String, variable: String) throws -> Tweak {
         let userDefaultsKey = keyForTweakWithIdentifier(variable)
         let userDefaultsValue = userDefaults.object(forKey: userDefaultsKey) as AnyObject?
-        guard let value = updateUserDefaults(userDefaultsValue) else { return nil }
+        guard let value = updateUserDefaults(userDefaultsValue) else { throw TweakError.notFound }
         
         return Tweak(
             feature: feature,

--- a/JustTweak/Classes/UI/TweakManager+Presentation.swift
+++ b/JustTweak/Classes/UI/TweakManager+Presentation.swift
@@ -12,15 +12,14 @@ extension TweakManager {
         for localTweakProvider in self.localTweakProviders.reversed() {
             for (feature, variables) in localTweakProvider.features {
                 for variable in variables {
-                    if let tweak = tweakWith(feature: feature, variable: variable),
-                        let jsonTweak = localTweakProvider.tweakWith(feature: feature, variable: variable) {
+                    if let tweak = try? tweakWith(feature: feature, variable: variable),
+                        let jsonTweak = try? localTweakProvider.tweakWith(feature: feature, variable: variable) {
                         let aggregatedTweak = Tweak(feature: feature,
                                                     variable: variable,
                                                     value: tweak.value,
                                                     title: jsonTweak.title,
                                                     description: jsonTweak.desc,
                                                     group: jsonTweak.group)
-                        
                         let key = "\(feature)-\(variable)"
                         tweaks[key] = aggregatedTweak
                     }

--- a/JustTweak/Classes/Utilities/PropertyWrappers.swift
+++ b/JustTweak/Classes/Utilities/PropertyWrappers.swift
@@ -19,8 +19,8 @@ public struct TweakProperty<T: TweakValue> {
     
     public var wrappedValue: T {
         get {
-            let tweak = tweakManager.tweakWith(feature: feature, variable: variable)
-            return tweak!.value as! T
+            let tweak = try? tweakManager.tweakWith(feature: feature, variable: variable)
+            return tweak?.value as! T
         }
         set {
             tweakManager.set(newValue, feature: feature, variable: variable)
@@ -44,7 +44,7 @@ public struct FallbackTweakProperty<T: TweakValue> {
     
     public var wrappedValue: T {
         get {
-            let tweak = tweakManager.tweakWith(feature: feature, variable: variable)
+            let tweak = try? tweakManager.tweakWith(feature: feature, variable: variable)
             return (tweak?.value as? T) ?? fallbackValue
         }
         set {
@@ -69,7 +69,7 @@ public struct OptionalTweakProperty<T: TweakValue> {
     
     public var wrappedValue: T? {
         get {
-            let tweak = tweakManager.tweakWith(feature: feature, variable: variable)
+            let tweak = try? tweakManager.tweakWith(feature: feature, variable: variable)
             return (tweak?.value as? T) ?? fallbackValue
         }
         set {

--- a/README.md
+++ b/README.md
@@ -152,8 +152,13 @@ do {
     // tweak was found in some tweak provider, use tweak.value
     return tweak    
 } catch let error as TweakError {
-    // tweak was not found in any tweak provider
-    //handle error
+    switch error {
+    case .notFound: () // "Feature or variable is not found"
+    case .notSupported: () // "Variable type is not supported"
+    case .decryptionClosureNotProvided: () // "Value is encrypted but there's no decryption closure provided"
+    }
+} catch let error { // add a default catch to satisfy the compiler
+    print(error.localizedDescription)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,17 +131,29 @@ if enabled {
 }
 ```
 
-2. Get the value of a flag for a given feature. `TweakManager` will return the value from the tweak provider with the highest priority and automatically fallback to the others if no set value is found.
+2. Get the value of a flag for a given feature. `TweakManager` will return the value from the tweak provider with the highest priority and automatically fallback to the others if no set value is found. It throws exeception when a nil Tweak is found which can be catched and handled as needed.
 
 Use either `tweakWith(feature:variable:)` or the provided property wrappers.
 
 ```swift
 // check for a tweak value
-let tweak = tweakManager.tweakWith(feature: "some_feature", variable: "some_flag")
+let tweak = try? tweakManager.tweakWith(feature: "some_feature", variable: "some_flag")
 if let tweak = tweak {
     // tweak was found in some tweak provider, use tweak.value
 } else {
     // tweak was not found in any tweak provider
+}
+```
+Or with do-catch
+```swift
+// check for a tweak value
+do {
+    let tweak = try tweakManager.tweakWith(feature: "some_feature", variable: "some_flag")
+    // tweak was found in some tweak provider, use tweak.value
+    return tweak    
+} catch let error as TweakError {
+    // tweak was not found in any tweak provider
+    //handle error
 }
 ```
 

--- a/TweakAccessorGenerator/TweakAccessorGenerator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TweakAccessorGenerator/TweakAccessorGenerator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "git@github.com:apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/TweakAccessorGenerator/TweakAccessorGenerator/Core/TweakAccessorCodeGenerator.swift
+++ b/TweakAccessorGenerator/TweakAccessorGenerator/Core/TweakAccessorCodeGenerator.swift
@@ -152,7 +152,7 @@ extension TweakAccessorCodeGenerator {
         let defaultValue = try! self.defaultValue(for: tweak.valueType)
         return """
             var \(propertyName): \(tweak.valueType) {
-                get { tweakManager.tweakWith(feature: \(feature), variable: \(variable))?.\(castProperty) ?? \(defaultValue) }
+                get { (try? tweakManager.tweakWith(feature: \(feature), variable: \(variable)))?.\(castProperty) ?? \(defaultValue) }
                 set { tweakManager.set(newValue, feature: \(feature), variable: \(variable)) }
             }
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The getter function of Tweak is made throwable

## Motivation and Context
 - With the addition of these changes #63 we now have multiple reasons where Tweak can be a nil value.
 - To better capture the error the getter is made throwable.

## How Has This Been Tested?
 - Tested the example app and updated the Unit tests.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
