### PR TITLE
Edit Configuration changes the wrong field

### DIFF
--- a/Framework/Sources/UI/Cells/BooleanTweakTableViewCell.swift
+++ b/Framework/Sources/UI/Cells/BooleanTweakTableViewCell.swift
@@ -6,7 +6,10 @@
 import UIKit
 
 internal class BooleanTweakTableViewCell: UITableViewCell, TweakViewControllerCell {
-    
+
+    private var _feature: String? = nil
+    private var _variable: String? = nil
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
     }
@@ -30,6 +33,26 @@ internal class BooleanTweakTableViewCell: UITableViewCell, TweakViewControllerCe
         }
         set {
             detailTextLabel?.text = newValue
+        }
+    }
+
+    var feature: String? {
+        get {
+            return self._feature
+        }
+
+        set {
+            self._feature = newValue
+        }
+    }
+
+    var variable: String? {
+        get {
+            return self._variable
+        }
+
+        set {
+            self._variable = newValue
         }
     }
     

--- a/Framework/Sources/UI/Cells/TextTweakTableViewCell.swift
+++ b/Framework/Sources/UI/Cells/TextTweakTableViewCell.swift
@@ -7,6 +7,9 @@ import UIKit
 
 class TextTweakTableViewCell: UITableViewCell, TweakViewControllerCell, UITextFieldDelegate {
 
+    private var _feature: String? = nil
+    private var _variable: String? = nil
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
     }
@@ -30,6 +33,26 @@ class TextTweakTableViewCell: UITableViewCell, TweakViewControllerCell, UITextFi
         }
         set {
             detailTextLabel?.text = newValue
+        }
+    }
+
+    var feature: String? {
+        get {
+            return self._feature
+        }
+
+        set {
+            self._feature = newValue
+        }
+    }
+
+    var variable: String? {
+        get {
+            return self._variable
+        }
+
+        set {
+            self._variable = newValue
         }
     }
     

--- a/Framework/Sources/UI/TweakViewController.swift
+++ b/Framework/Sources/UI/TweakViewController.swift
@@ -8,6 +8,8 @@ import UIKit
 internal protocol TweakViewControllerCell: AnyObject {
     var title: String? { get set }
     var desc: String? { get set }
+    var feature: String? { get set }
+    var variable: String? { get set }
     var value: TweakValue { get set }
     var delegate: TweakViewControllerCellDelegate? { get set }
 }
@@ -103,6 +105,8 @@ extension TweakViewController {
         if let cell = cell as? TweakViewControllerCell {
             cell.title = tweak.title ?? "\(tweak.feature):\(tweak.variable)"
             cell.desc = tweak.desc
+            cell.feature = tweak.feature
+            cell.variable = tweak.variable
             cell.value = tweak.value
             cell.delegate = self
         }
@@ -227,12 +231,14 @@ extension TweakViewController {
 extension TweakViewController: TweakViewControllerCellDelegate {
     
     internal func tweakConfigurationCellDidChangeValue(_ cell: TweakViewControllerCell) {
-        if let indexPath = tableView.indexPath(for: cell as! UITableViewCell) {
-            if let tweak = tweakAt(indexPath: indexPath) {
-                let feature = tweak.feature
-                let variable = tweak.variable
-                tweakManager.set(cell.value, feature: feature, variable: variable)
-                tweak.value = cell.value
+        if let feature = cell.feature, let variable = cell.variable {
+            if let indexPath = indexPathForTweak(with: feature, variable: variable) {
+                if let tweak = tweakAt(indexPath: indexPath){
+                    let feature = tweak.feature
+                    let variable = tweak.variable
+                    tweakManager.set(cell.value, feature: feature, variable: variable)
+                    tweak.value = cell.value
+                }
             }
         }
     }


### PR DESCRIPTION
Edit Configuration changes the wrong field

<!--- Provide a general summary of your changes in the Title above -->

## Description
If you change the “Search Tweaks” filter in “Edit Configuration” without navigating off a changed field, then it may update a different field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Run the app.
Move to Edit Configuration page.
Specify a search string, e.g. “xyz”.
Scroll to the setting you want to edit and type a new value without tapping Done or navigating to another field.
Tap on the clear field button of the search field.
Note that another field has been updated with the new value.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually tested it in Demo App.
Run all the unit tests and made sure they are passing.
Check if there is a need to write any new tests for changes.
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
